### PR TITLE
LunarG samples support (7, 8, 9, 11)

### DIFF
--- a/libportability-gfx/src/conv.rs
+++ b/libportability-gfx/src/conv.rs
@@ -1,4 +1,4 @@
-use hal::{adapter, buffer, format, image, memory, window};
+use hal::{adapter, buffer, format, image, memory, pso, window};
 
 use std::mem;
 
@@ -267,6 +267,57 @@ pub fn memory_properties_from_hal(properties: memory::Properties) -> VkMemoryPro
     }
     if properties.contains(memory::Properties::LAZILY_ALLOCATED) {
         flags |= VkMemoryPropertyFlagBits::VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT as u32;
+    }
+
+    flags
+}
+
+pub fn map_descriptor_type(ty: VkDescriptorType) -> pso::DescriptorType {
+    use super::VkDescriptorType::*;
+
+    match ty {
+        VK_DESCRIPTOR_TYPE_SAMPLER => pso::DescriptorType::Sampler,
+        VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE => pso::DescriptorType::SampledImage,
+        VK_DESCRIPTOR_TYPE_STORAGE_IMAGE => pso::DescriptorType::StorageImage,
+        VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER => pso::DescriptorType::UniformTexelBuffer,
+        VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER => pso::DescriptorType::StorageTexelBuffer,
+        VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER => pso::DescriptorType::UniformBuffer,
+        VK_DESCRIPTOR_TYPE_STORAGE_BUFFER => pso::DescriptorType::StorageBuffer,
+        VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT => pso::DescriptorType::InputAttachment,
+
+        VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER |
+        VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC |
+        VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC => unimplemented!(),
+        _ => panic!("Unexpected descriptor type: {:?}", ty),
+    }
+}
+
+pub fn map_stage_flags(stages: VkShaderStageFlags) -> pso::ShaderStageFlags {
+    let mut flags = pso::ShaderStageFlags::empty();
+
+    if stages & VkShaderStageFlagBits::VK_SHADER_STAGE_VERTEX_BIT as u32 != 0 {
+        flags |= pso::ShaderStageFlags::VERTEX;
+    }
+    if stages & VkShaderStageFlagBits::VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT as u32 != 0 {
+        flags |= pso::ShaderStageFlags::HULL;
+    }
+    if stages & VkShaderStageFlagBits::VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT as u32 != 0 {
+        flags |= pso::ShaderStageFlags::DOMAIN;
+    }
+    if stages & VkShaderStageFlagBits::VK_SHADER_STAGE_GEOMETRY_BIT as u32 != 0 {
+        flags |= pso::ShaderStageFlags::GEOMETRY;
+    }
+    if stages & VkShaderStageFlagBits::VK_SHADER_STAGE_FRAGMENT_BIT as u32 != 0 {
+        flags |= pso::ShaderStageFlags::FRAGMENT;
+    }
+    if stages & VkShaderStageFlagBits::VK_SHADER_STAGE_COMPUTE_BIT as u32 != 0 {
+        flags |= pso::ShaderStageFlags::COMPUTE;
+    }
+    if stages & VkShaderStageFlagBits::VK_SHADER_STAGE_ALL_GRAPHICS as u32 != 0 {
+        flags |= pso::ShaderStageFlags::GRAPHICS;
+    }
+    if stages & VkShaderStageFlagBits::VK_SHADER_STAGE_ALL as u32 != 0 {
+        flags |= pso::ShaderStageFlags::ALL;
     }
 
     flags

--- a/libportability-gfx/src/conv.rs
+++ b/libportability-gfx/src/conv.rs
@@ -176,6 +176,24 @@ pub fn map_image_kind(
     }
 }
 
+pub fn map_image_layout(layout: VkImageLayout) -> image::ImageLayout {
+    match layout {
+        /*
+        VK_IMAGE_LAYOUT_UNDEFINED = 0,
+        VK_IMAGE_LAYOUT_GENERAL = 1,
+        VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL = 2,
+        VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL = 3,
+        VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL = 4,
+        VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL = 5,
+        VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL = 6,
+        VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL = 7,
+        VK_IMAGE_LAYOUT_PREINITIALIZED = 8,
+        VK_IMAGE_LAYOUT_PRESENT_SRC_KHR = 1000001002,
+        */
+        _ => unimplemented!(),
+    }
+}
+
 fn map_aa_mode(samples: VkSampleCountFlagBits) -> image::AaMode {
     use VkSampleCountFlagBits::*;
 

--- a/libportability-gfx/src/impls.rs
+++ b/libportability-gfx/src/impls.rs
@@ -790,20 +790,33 @@ pub extern "C" fn gfxDestroyImageView(
 }
 #[inline]
 pub extern "C" fn gfxCreateShaderModule(
-    device: VkDevice,
+    gpu: VkDevice,
     pCreateInfo: *const VkShaderModuleCreateInfo,
-    pAllocator: *const VkAllocationCallbacks,
+    _pAllocator: *const VkAllocationCallbacks,
     pShaderModule: *mut VkShaderModule,
 ) -> VkResult {
-    unimplemented!()
+    let info = unsafe { &*pCreateInfo };
+    let code = unsafe {
+        slice::from_raw_parts(info.pCode as *const u8, info.codeSize as usize)
+    };
+
+    let shader_module = gpu
+        .device
+        .create_shader_module(code)
+        .expect("Error creating shader module"); // TODO
+
+    unsafe {
+        *pShaderModule = Handle::new(shader_module);
+    }
+    VkResult::VK_SUCCESS
 }
 #[inline]
 pub extern "C" fn gfxDestroyShaderModule(
-    device: VkDevice,
+    gpu: VkDevice,
     shaderModule: VkShaderModule,
-    pAllocator: *const VkAllocationCallbacks,
+    _pAllocator: *const VkAllocationCallbacks,
 ) {
-    unimplemented!()
+    gpu.device.destroy_shader_module(*shaderModule.unwrap());
 }
 #[inline]
 pub extern "C" fn gfxCreatePipelineCache(

--- a/libportability-gfx/src/impls.rs
+++ b/libportability-gfx/src/impls.rs
@@ -430,14 +430,16 @@ pub extern "C" fn gfxBindBufferMemory(
     memory: VkDeviceMemory,
     memoryOffset: VkDeviceSize,
 ) -> VkResult {
-    *buffer = match *buffer {
-        Buffer::Buffer(_) => panic!("An Buffer can only be bound once!"),
-        Buffer::Unbound(ref mut unbound) => {
-            Buffer::Buffer(unsafe {
+    let temp = unsafe { mem::zeroed() };
+
+    *buffer = match mem::replace(&mut *buffer, temp) {
+        Buffer::Buffer(_) => panic!("An non-sparse buffer can only be bound once!"),
+        Buffer::Unbound(unbound) => {
+            Buffer::Buffer(
                 gpu.device
-                    .bind_buffer_memory_raw(&memory, memoryOffset, unbound)
+                    .bind_buffer_memory(&memory, memoryOffset, unbound)
                     .unwrap() // TODO
-            })
+            )
         }
     };
 
@@ -450,14 +452,16 @@ pub extern "C" fn gfxBindImageMemory(
     memory: VkDeviceMemory,
     memoryOffset: VkDeviceSize,
 ) -> VkResult {
-    *image = match *image {
-        Image::Image(_) => panic!("An Image can only be bound once!"),
-        Image::Unbound(ref mut unbound) => {
-            Image::Image(unsafe {
+    let temp = unsafe { mem::zeroed() };
+
+    *image = match mem::replace(&mut *image, temp) {
+        Image::Image(_) => panic!("An non-sparse image can only be bound once!"),
+        Image::Unbound(unbound) => {
+            Image::Image(
                 gpu.device
-                    .bind_image_memory_raw(&memory, memoryOffset, unbound)
+                    .bind_image_memory(&memory, memoryOffset, unbound)
                     .unwrap() // TODO
-            })
+            )
         }
     };
 

--- a/libportability-gfx/src/lib.rs
+++ b/libportability-gfx/src/lib.rs
@@ -30,6 +30,7 @@ pub type VkDevice = Handle<hal::Gpu<B>>;
 pub type VkCommandPool = Handle<<B as hal::Backend>::CommandPool>;
 pub type VkCommandBuffer = Handle<<B as hal::Backend>::CommandBuffer>;
 pub type VkDeviceMemory = Handle<<B as hal::Backend>::Memory>;
+pub type VkDescriptorSetLayout = Handle<<B as hal::Backend>::DescriptorSetLayout>;
 
 pub enum Image<B: hal::Backend> {
     Image(B::Image),
@@ -570,12 +571,6 @@ pub struct VkPipeline_T {
     _unused: [u8; 0],
 }
 pub type VkPipeline = *mut VkPipeline_T;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct VkDescriptorSetLayout_T {
-    _unused: [u8; 0],
-}
-pub type VkDescriptorSetLayout = *mut VkDescriptorSetLayout_T;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct VkSampler_T {

--- a/libportability-gfx/src/lib.rs
+++ b/libportability-gfx/src/lib.rs
@@ -17,7 +17,6 @@ mod handle;
 mod impls;
 
 use std::{cmp, slice};
-use hal::pool::RawCommandPool;
 use back::Backend as B;
 use handle::Handle;
 
@@ -32,6 +31,10 @@ pub type VkCommandBuffer = Handle<<B as hal::Backend>::CommandBuffer>;
 pub type VkDeviceMemory = Handle<<B as hal::Backend>::Memory>;
 pub type VkDescriptorSetLayout = Handle<<B as hal::Backend>::DescriptorSetLayout>;
 pub type VkPipelineLayout = Handle<<B as hal::Backend>::PipelineLayout>;
+pub type VkDescriptorPool = Handle<<B as hal::Backend>::DescriptorPool>;
+pub type VkDescriptorSet = Handle<<B as hal::Backend>::DescriptorSet>;
+pub type VkSampler = Handle<<B as hal::Backend>::Sampler>;
+pub type VkBufferView = Handle<<B as hal::Backend>::BufferView>;
 
 pub enum Image<B: hal::Backend> {
     Image(B::Image),
@@ -537,13 +540,6 @@ pub struct VkQueryPool_T {
 pub type VkQueryPool = *mut VkQueryPool_T;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct VkBufferView_T {
-    _unused: [u8; 0],
-}
-pub type VkBufferView = *mut VkBufferView_T;
-
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
 pub struct VkShaderModule_T {
     _unused: [u8; 0],
 }
@@ -566,24 +562,6 @@ pub struct VkPipeline_T {
     _unused: [u8; 0],
 }
 pub type VkPipeline = *mut VkPipeline_T;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct VkSampler_T {
-    _unused: [u8; 0],
-}
-pub type VkSampler = *mut VkSampler_T;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct VkDescriptorPool_T {
-    _unused: [u8; 0],
-}
-pub type VkDescriptorPool = *mut VkDescriptorPool_T;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct VkDescriptorSet_T {
-    _unused: [u8; 0],
-}
-pub type VkDescriptorSet = *mut VkDescriptorSet_T;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct VkFramebuffer_T {

--- a/libportability-gfx/src/lib.rs
+++ b/libportability-gfx/src/lib.rs
@@ -31,6 +31,7 @@ pub type VkCommandPool = Handle<<B as hal::Backend>::CommandPool>;
 pub type VkCommandBuffer = Handle<<B as hal::Backend>::CommandBuffer>;
 pub type VkDeviceMemory = Handle<<B as hal::Backend>::Memory>;
 pub type VkDescriptorSetLayout = Handle<<B as hal::Backend>::DescriptorSetLayout>;
+pub type VkPipelineLayout = Handle<<B as hal::Backend>::PipelineLayout>;
 
 pub enum Image<B: hal::Backend> {
     Image(B::Image),
@@ -553,12 +554,6 @@ pub struct VkPipelineCache_T {
     _unused: [u8; 0],
 }
 pub type VkPipelineCache = *mut VkPipelineCache_T;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct VkPipelineLayout_T {
-    _unused: [u8; 0],
-}
-pub type VkPipelineLayout = *mut VkPipelineLayout_T;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct VkRenderPass_T {

--- a/libportability-gfx/src/lib.rs
+++ b/libportability-gfx/src/lib.rs
@@ -35,6 +35,7 @@ pub type VkDescriptorPool = Handle<<B as hal::Backend>::DescriptorPool>;
 pub type VkDescriptorSet = Handle<<B as hal::Backend>::DescriptorSet>;
 pub type VkSampler = Handle<<B as hal::Backend>::Sampler>;
 pub type VkBufferView = Handle<<B as hal::Backend>::BufferView>;
+pub type VkShaderModule = Handle<<B as hal::Backend>::ShaderModule>;
 
 pub enum Image<B: hal::Backend> {
     Image(B::Image),
@@ -538,12 +539,6 @@ pub struct VkQueryPool_T {
     _unused: [u8; 0],
 }
 pub type VkQueryPool = *mut VkQueryPool_T;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct VkShaderModule_T {
-    _unused: [u8; 0],
-}
-pub type VkShaderModule = *mut VkShaderModule_T;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct VkPipelineCache_T {


### PR DESCRIPTION
Implement necessary functionality for LunarG API-Samples 7 (uniform buffer), 8 (pipeline layout), 9 (descriptor set) and 11 (shaders).

Merge + rebase of two outstanding gfx PRs to run.