### PR TITLE
Fix physical device enumeration and add dummy features

### DIFF
--- a/libportability-gfx/src/handle.rs
+++ b/libportability-gfx/src/handle.rs
@@ -11,6 +11,10 @@ impl<T> Handle<T> {
         Handle(ptr)
     }
 
+    pub fn null() -> Self {
+        Handle(VK_NULL_HANDLE as *mut _)
+    }
+
     pub fn unwrap(self) -> Box<T> {
         unsafe { Box::from_raw(self.0) }
     }
@@ -72,6 +76,10 @@ mod dispatch {
         pub fn new(value: T) -> Self {
             let ptr = Box::into_raw(Box::new((ICD_LOADER_MAGIC, value)));
             DispatchHandle(ptr)
+        }
+
+        pub fn null() -> Self {
+            DispatchHandle(VK_NULL_HANDLE as *mut _)
         }
 
         pub fn unwrap(self) -> Box<(u64, T)> {

--- a/libportability-gfx/src/lib.rs
+++ b/libportability-gfx/src/lib.rs
@@ -30,9 +30,15 @@ use std::collections::HashMap;
 
 pub use impls::*;
 
+
 // Vulkan objects
-pub type VkInstance = Handle<back::Instance>;
-pub type VkPhysicalDevice = DispatchHandle<hal::Adapter<B>>;
+pub type VkPhysicalDevice = Handle<hal::Adapter<B>>;
+
+pub struct RawInstance {
+    pub backend: back::Instance,
+    pub adapters: Vec<VkPhysicalDevice>,
+}
+pub type VkInstance = Handle<RawInstance>;
 pub type VkDevice = DispatchHandle<Gpu<B>>;
 pub type VkQueue = DispatchHandle<<B as hal::Backend>::CommandQueue>;
 pub type VkCommandPool = Handle<<B as hal::Backend>::CommandPool>;


### PR DESCRIPTION
Vulkan loader expects that EnumeratePhysicalDevices will return the same handles on each call. Caching them on startup