### PR TITLE
Return VK_INCOMPLETE for partial physical device enumeration

### DIFF
--- a/libportability-gfx/src/lib.rs
+++ b/libportability-gfx/src/lib.rs
@@ -25,7 +25,7 @@ mod impls;
 use back::Backend as B;
 use handle::{DispatchHandle, Handle};
 
-use std::{cmp, slice};
+use std::{slice};
 use std::collections::HashMap;
 
 pub use impls::*;


### PR DESCRIPTION
Trivial fix for `dEQP-VK.api.info.instance.physical_devices: Query didn't return VK_INCOMPLETE(Fail)` (only tested with Metal CTS).

[Reference:](https://www.khronos.org/registry/vulkan/specs/1.0/man/html/vkEnumeratePhysicalDevices.html)
> If pPhysicalDeviceCount is smaller than the number of physical devices available, VK_INCOMPLETE will be returned instead of VK_SUCCESS, to indicate that not all the available physical devices were returned.