### PR TITLE
Implement ResetFences and GetFenceStatus

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,14 @@ This is a prototype library implementing [Vulkan Portability Initiative](https:/
 
 | gfx-rs Backend | Total cases | Pass | Fail | Quality warning | Compatibility warning | Not supported | Resource error | Internal error | Timeout | Crash |
 | -------- | ---- | ---- | --- | -- | - | ---- | - | - | - | - |
-| *Vulkan* | 3914 | 1516 | 120 | 30 | 0 | 2248 | 0 | 0 | 0 | 0 |
+| *Vulkan* | 7723 | 2236 | 66  | 34 | 0 | 5387 | 0 | 0 | 0 | 0 |
 | *DX12*   | 3563 | 1243 | 73  | 0  | 0 | 2247 | 0 | 0 | 0 | 0 |
 | *Metal*  | 3710 | 1260 | 66  | 0  | 0 | 2384 | 0 | 0 | 0 | 0 |
 
+DX12 and Metal measurement are currently out of date.
+  
 Currently stopping with:
-> Unable to create Vulkan instance: VkError(ErrorIncompatibleDriver)
+> (RADV ARCH VULKAN) radv_BeginCommandBuffer: Assertion `pBeginInfo->pInheritanceInfo' failed.
 
 Please visit [our wiki](https://github.com/gfx-rs/portability/wiki/Vulkan-CTS-status) for CTS hookup instructions. Once everything is set, you can generate the new results by calling `make cts` on Unix systems.
 

--- a/libportability-gfx/src/impls.rs
+++ b/libportability-gfx/src/impls.rs
@@ -950,15 +950,27 @@ pub extern "C" fn gfxDestroyFence(
 }
 #[inline]
 pub extern "C" fn gfxResetFences(
-    device: VkDevice,
+    gpu: VkDevice,
     fenceCount: u32,
     pFences: *const VkFence,
 ) -> VkResult {
-    unimplemented!()
+    let fence_slice = unsafe {
+        slice::from_raw_parts(pFences, fenceCount as _)
+    };
+    let fences = fence_slice
+        .into_iter()
+        .map(|fence| &**fence);
+
+    gpu.device.reset_fences(fences);
+    VkResult::VK_SUCCESS
 }
 #[inline]
-pub extern "C" fn gfxGetFenceStatus(device: VkDevice, fence: VkFence) -> VkResult {
-    unimplemented!()
+pub extern "C" fn gfxGetFenceStatus(gpu: VkDevice, fence: VkFence) -> VkResult {
+    if gpu.device.get_fence_status(&*fence) {
+        VkResult::VK_SUCCESS
+    } else {
+        VkResult::VK_NOT_READY
+    }
 }
 #[inline]
 pub extern "C" fn gfxWaitForFences(
@@ -1016,7 +1028,9 @@ pub extern "C" fn gfxCreateEvent(
     _pAllocator: *const VkAllocationCallbacks,
     pEvent: *mut VkEvent,
 ) -> VkResult {
-    unimplemented!()
+    // Vulkan portability doesn't currently support events, but some
+    // test cases use them so fail with an obvious error message.
+    VkResult::VK_ERROR_DEVICE_LOST
 }
 #[inline]
 pub extern "C" fn gfxDestroyEvent(


### PR DESCRIPTION
My drivers seem to be a bit odd so these measurements may need to be repeated.
I have added an error on `gfxCreateEvent` to workaround it causing the CTS to crash as events are not currently supported by Vulkan portability.