### PR TITLE
Support for Vulkan Samples with ICD

### DIFF
--- a/libportability-gfx/src/impls.rs
+++ b/libportability-gfx/src/impls.rs
@@ -793,13 +793,15 @@ pub extern "C" fn gfxMapMemory(
     _flags: VkMemoryMapFlags,
     ppData: *mut *mut ::std::os::raw::c_void,
 ) -> VkResult {
-    if size == VK_WHOLE_SIZE as VkDeviceSize {
-        unimplemented!()
-    }
+    let range = if size == VK_WHOLE_SIZE as VkDeviceSize {
+        (Some(offset), None)
+    } else {
+        (Some(offset), Some(offset + size))
+    };
 
     unsafe {
         *ppData = gpu.device
-            .map_memory(&memory, offset..offset + size)
+            .map_memory(&memory, range)
             .unwrap() as *mut _; // TODO
     }
 

--- a/libportability-gfx/src/lib.rs
+++ b/libportability-gfx/src/lib.rs
@@ -6828,3 +6828,10 @@ pub type PFN_vkDestroyInstance = ::std::option::Option<unsafe extern "C" fn(
     instance: VkInstance,
     pAllocator: *const VkAllocationCallbacks,
 )>;
+
+pub type PFN_vkCreateWin32SurfaceKHR = ::std::option::Option<unsafe extern "C" fn(
+    instance: VkInstance,
+    pCreateInfo: *const VkWin32SurfaceCreateInfoKHR,
+    pAllocator: *const VkAllocationCallbacks,
+    pSurface: *mut VkSurfaceKHR,
+) -> VkResult>;


### PR DESCRIPTION
Add a few missing piece to get Vulkan Samples working with ICD (dx12, windows):
* Expose device extensions (partially)
* Expose addr to CreateWin32SurfaceKHR

Additionally, fixing vkMapMemory for the `VK_WHOLE_SIZE` case.