### PR TITLE
Remove tiling assert

### DIFF
--- a/libportability-gfx/src/impls.rs
+++ b/libportability-gfx/src/impls.rs
@@ -1243,7 +1243,6 @@ pub extern "C" fn gfxCreateImage(
 ) -> VkResult {
     let info = unsafe { &*pCreateInfo };
     assert_eq!(info.sharingMode, VkSharingMode::VK_SHARING_MODE_EXCLUSIVE); // TODO
-    assert_eq!(info.tiling, VkImageTiling::VK_IMAGE_TILING_OPTIMAL); // TODO
     assert_eq!(info.initialLayout, VkImageLayout::VK_IMAGE_LAYOUT_UNDEFINED); // TODO
 
     let image = gpu.device


### PR DESCRIPTION
As far as I can tell, we shouldn't need this assert anymore because we already perform the mapping immediately below.

Unless there is another reason it needs to stay (maybe validating against image format queries?), let's remove it because it causes other unrelated tests to fail.