### PR TITLE
Build with panic=abort

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,6 @@ members = [
     "libportability-gfx",
     "libportability-icd",
 ]
+
+[profile.release]
+panic = "abort"


### PR DESCRIPTION
This drops the size of libportability.dylib from 2.4M to 2.1M and
gives the compiler better opportunities for optimization.