### PR TITLE
Deployment configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,9 +53,7 @@ script:
   - export PATH=$PATH:$HOME/deps/bin
   - make
   - if [[ $TRAVIS_RUST_VERSION == "nightly" ]]; then make debug release; fi
-
-after_success:
-  - if [[ $TRAVIS_RUST_VERSION != "nightly" && $TRAVIS_BRANCH == "master" ]]; then make package.zip && mv package.zip portability-$TRAVIS_OS_NAME.zip; fi
+  - if [[ $TRAVIS_RUST_VERSION != "nightly" && $TRAVIS_BRANCH == "master" && $TRAVIS_OS_NAME == "osx" ]]; then make package.zip && mv package.zip portability-$TRAVIS_OS_NAME.zip; fi
 
 deploy:
   provider: releases
@@ -65,3 +63,6 @@ deploy:
   skip_cleanup: true
   on:
     tags: true
+    branch: master
+    condition: $TRAVIS_RUST_VERSION = "stable" && $TRAVIS_OS_NAME == "osx"
+    skip_cleanup: true


### PR DESCRIPTION
Continue deployment configuration:

- just run everything in `script` instead of separating them
- only attempt to deploy for Rust stable builds
- `skip_cleanup` forces temporary build artifacts not to be cleared and seems to be recommended for this deployment