### PR TITLE
Allow Linux binaries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,13 +53,13 @@ script:
   - export PATH=$PATH:$HOME/deps/bin
   - make
   - if [[ $TRAVIS_RUST_VERSION == "nightly" ]]; then make debug release; fi
-  - if [[ $TRAVIS_RUST_VERSION == "stable" && $TRAVIS_BRANCH == $TRAVIS_TAG && $TRAVIS_OS_NAME == "osx" ]]; then make package.zip && mv package.zip portability-$TRAVIS_OS_NAME.zip; fi
+  - if [[ $TRAVIS_RUST_VERSION == "stable" && $TRAVIS_BRANCH == $TRAVIS_TAG && $TRAVIS_OS_NAME == "osx" ]]; then make package.zip && mv package.zip gfx-portability-$TRAVIS_OS_NAME-$TRAVIS_COMMIT.zip; fi
 
 deploy:
   provider: releases
   api_key:
     secure: kS8vjHOnLEknb2qxf2dPxMW8S5KcpjSkSgoi23WXiX3DZ2v8DIJMxVLanJhD3mbr1oI1NGXQHrTeeA/HBEEJcOVzlQo38MgNo/Jyt1k4jLRyCEDL0LjO+M1zAQGoEDWlyyjeu+Alw3SFKqGoZeuYDZ/mxUpEapFMD++8w4IjON2fI6iNumcIMeAg3Ns6Y4wHYQPzfIQQf5svI9dh1lf7PhlFB/btONBPi6rXxU/UwCnHBoOPydl5OwjggaUAjCJSf8i/FDLWt5XpvA2UsML2AbcFNuwFhNGhf6ArwEsqgcMCGL6jACetvI/l3ZL96h5dsgzRLW0ruvnvpEm3y3aw9wCjEAcnQMZCBPlIfOpj5MH/guh526QWCVQ3rwRUJOhua9T2yvwda3ICYspyVShzlbwscA9yLwvsuO+6Hl+upuE2IPfLvS6QpnXVlIWHe/3HqOoQggDdsWvnZhhGNKASKsi9vNgTvec/1iX846/KGcV3nYeHIWFrvP0IgWtEqQrgcWj9w6X7LDdaTFmrkKwKnNn4ClLQYPnlWQS71iX0gwRhONGaSAEfFca6vwVTa8AGSQUEHphe5lT7LtAy6UhlbjZNuKvUR+pn+l0EoWlZzm+uxKMtGR+mG9h6My+GA3hCWWtX/Xc94TvuJ1cg+uRu48+rD21vv3cr2fEVDRq7pGg=
-  file: portability-$TRAVIS_OS_NAME.zip
+  file: gfx-portability-$TRAVIS_OS_NAME-$TRAVIS_COMMIT.zip
   skip_cleanup: true
   on:
     tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ script:
   - export PATH=$PATH:$HOME/deps/bin
   - make
   - if [[ $TRAVIS_RUST_VERSION == "nightly" ]]; then make debug release; fi
-  - if [[ $TRAVIS_RUST_VERSION == "stable" && $TRAVIS_BRANCH == $TRAVIS_TAG && $TRAVIS_OS_NAME == "osx" ]]; then make package.zip && mv package.zip gfx-portability-$TRAVIS_OS_NAME-$TRAVIS_COMMIT.zip; fi
+  - if [[ $TRAVIS_RUST_VERSION == "stable" && $TRAVIS_BRANCH == $TRAVIS_TAG ]]; then make package.zip && mv package.zip gfx-portability-$TRAVIS_OS_NAME-$TRAVIS_COMMIT.zip; fi
 
 deploy:
   provider: releases
@@ -63,5 +63,5 @@ deploy:
   skip_cleanup: true
   on:
     tags: true
-    condition: $TRAVIS_RUST_VERSION == "stable" && $TRAVIS_BRANCH == $TRAVIS_TAG && $TRAVIS_OS_NAME == "osx"
+    condition: $TRAVIS_RUST_VERSION == "stable" && $TRAVIS_BRANCH == $TRAVIS_TAG
     skip_cleanup: true

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ TEST_LIST=$(CURDIR)/conformance/deqp.txt
 TEST_LIST_SOURCE=$(CTS_DIR)/external/vulkancts/mustpass/1.0.2/vk-default.txt
 DEQP_DIR=$(CTS_DIR)/build/external/vulkancts/modules/vulkan/
 DEQP=cd $(DEQP_DIR) && RUST_LOG=debug LD_LIBRARY_PATH=$(FULL_LIBRARY_PATH) ./deqp-vk
+CURRENT_VERSION_ARG=
+COMPATIBILITY_VERSION_ARG=
 
 DOTA_DIR=../dota2/bin/osx64
 DOTA_EXE=$(DOTA_DIR)/dota2.app/Contents/MacOS/dota2
@@ -45,6 +47,8 @@ else
 		BACKEND=metal
 		DEBUGGER=rust-lldb --
 		LIB_EXTENSION=dylib
+		CURRENT_VERSION_ARG=-current_version 1.0.0
+		COMPATIBILITY_VERSION_ARG=-compatibility_version 1.0.0
 	endif
 endif
 
@@ -65,10 +69,10 @@ debug:
 release: $(LIBRARY_FAST)
 
 version-debug:
-	cargo rustc --manifest-path libportability/Cargo.toml --features $(BACKEND),portability-gfx/env_logger -- -Clink-arg="-current_version 1.0.0" -Clink-arg="-compatibility_version 1.0.0"
+	cargo rustc --manifest-path libportability/Cargo.toml --features $(BACKEND),portability-gfx/env_logger -- -Clink-arg="$(CURRENT_VERSION_ARG)" -Clink-arg="$(COMPATIBILITY_VERSION_ARG)"
 
 version-release:
-	cargo rustc --release --manifest-path libportability/Cargo.toml --features $(BACKEND) -- -Clink-arg="-current_version 1.0.0" -Clink-arg="-compatibility_version 1.0.0"
+	cargo rustc --release --manifest-path libportability/Cargo.toml --features $(BACKEND) -- -Clink-arg="$(CURRENT_VERSION_ARG)" -Clink-arg="$(COMPATIBILITY_VERSION_ARG)"
 
 
 dota-debug: version-debug $(DOTA_EXE)


### PR DESCRIPTION
- Include commit SHA in binary filename
- Only set current and compatibility versions on Darwin which should allow Linux targets to use `make package.zip`