### PR TITLE
Prevent empty cc arguments on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,7 @@ TEST_LIST=$(CURDIR)/conformance/deqp.txt
 TEST_LIST_SOURCE=$(CTS_DIR)/external/vulkancts/mustpass/1.0.2/vk-default.txt
 DEQP_DIR=$(CTS_DIR)/build/external/vulkancts/modules/vulkan/
 DEQP=cd $(DEQP_DIR) && RUST_LOG=debug LD_LIBRARY_PATH=$(FULL_LIBRARY_PATH) ./deqp-vk
-CURRENT_VERSION_ARG=
-COMPATIBILITY_VERSION_ARG=
+CLINK_ARGS=
 
 DOTA_DIR=../dota2/bin/osx64
 DOTA_EXE=$(DOTA_DIR)/dota2.app/Contents/MacOS/dota2
@@ -47,8 +46,7 @@ else
 		BACKEND=metal
 		DEBUGGER=rust-lldb --
 		LIB_EXTENSION=dylib
-		CURRENT_VERSION_ARG=-current_version 1.0.0
-		COMPATIBILITY_VERSION_ARG=-compatibility_version 1.0.0
+		CLINK_ARGS=-- -Clink-arg="-current_version 1.0.0" -Clink-arg="-compatibility_version 1.0.0"
 	endif
 endif
 
@@ -69,10 +67,10 @@ debug:
 release: $(LIBRARY_FAST)
 
 version-debug:
-	cargo rustc --manifest-path libportability/Cargo.toml --features $(BACKEND),portability-gfx/env_logger -- -Clink-arg="$(CURRENT_VERSION_ARG)" -Clink-arg="$(COMPATIBILITY_VERSION_ARG)"
+	cargo rustc --manifest-path libportability/Cargo.toml --features $(BACKEND),portability-gfx/env_logger $(CLINK_ARGS)
 
 version-release:
-	cargo rustc --release --manifest-path libportability/Cargo.toml --features $(BACKEND) -- -Clink-arg="$(CURRENT_VERSION_ARG)" -Clink-arg="$(COMPATIBILITY_VERSION_ARG)"
+	cargo rustc --release --manifest-path libportability/Cargo.toml --features $(BACKEND) $(CLINK_ARGS)
 
 
 dota-debug: version-debug $(DOTA_EXE)


### PR DESCRIPTION
I believe [the deployment error on Linux](https://travis-ci.org/gfx-rs/portability/jobs/421412694#L956) is caused by passing empty strings to cc on Linux. This PR attempts to address it by conditionally including the full Clink-arg string as a single variable instead.