### PR TITLE
Use short commit SHA and single level of directories for binaries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,13 +53,14 @@ script:
   - export PATH=$PATH:$HOME/deps/bin
   - make
   - if [[ $TRAVIS_RUST_VERSION == "nightly" ]]; then make debug release; fi
-  - if [[ $TRAVIS_RUST_VERSION == "stable" && $TRAVIS_BRANCH == $TRAVIS_TAG ]]; then make package.zip && mv package.zip gfx-portability-$TRAVIS_OS_NAME-$TRAVIS_COMMIT.zip; fi
+  - if [[ $TRAVIS_RUST_VERSION == "stable" && $TRAVIS_BRANCH == $TRAVIS_TAG ]]; then make package.zip; fi
 
 deploy:
   provider: releases
   api_key:
     secure: kS8vjHOnLEknb2qxf2dPxMW8S5KcpjSkSgoi23WXiX3DZ2v8DIJMxVLanJhD3mbr1oI1NGXQHrTeeA/HBEEJcOVzlQo38MgNo/Jyt1k4jLRyCEDL0LjO+M1zAQGoEDWlyyjeu+Alw3SFKqGoZeuYDZ/mxUpEapFMD++8w4IjON2fI6iNumcIMeAg3Ns6Y4wHYQPzfIQQf5svI9dh1lf7PhlFB/btONBPi6rXxU/UwCnHBoOPydl5OwjggaUAjCJSf8i/FDLWt5XpvA2UsML2AbcFNuwFhNGhf6ArwEsqgcMCGL6jACetvI/l3ZL96h5dsgzRLW0ruvnvpEm3y3aw9wCjEAcnQMZCBPlIfOpj5MH/guh526QWCVQ3rwRUJOhua9T2yvwda3ICYspyVShzlbwscA9yLwvsuO+6Hl+upuE2IPfLvS6QpnXVlIWHe/3HqOoQggDdsWvnZhhGNKASKsi9vNgTvec/1iX846/KGcV3nYeHIWFrvP0IgWtEqQrgcWj9w6X7LDdaTFmrkKwKnNn4ClLQYPnlWQS71iX0gwRhONGaSAEfFca6vwVTa8AGSQUEHphe5lT7LtAy6UhlbjZNuKvUR+pn+l0EoWlZzm+uxKMtGR+mG9h6My+GA3hCWWtX/Xc94TvuJ1cg+uRu48+rD21vv3cr2fEVDRq7pGg=
-  file: gfx-portability-$TRAVIS_OS_NAME-$TRAVIS_COMMIT.zip
+  file_glob: true
+  file: gfx-portability-*.zip
   skip_cleanup: true
   on:
     tags: true

--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,7 @@ clean:
 	cargo clean
 
 package: version-debug version-release
-	cd target && zip ../gfx-portability-$(OS_NAME)-$(GIT_TAG).zip */libportability.$(LIB_EXTENSION) ../.git/refs/heads/master
+	cd target && cp ../.git/refs/heads/master commit-sha && zip ../gfx-portability-$(OS_NAME)-$(GIT_TAG).zip */libportability.$(LIB_EXTENSION) commit-sha
 
 target/debug/libvulkan.$(LIB_EXTENSION):
 	cd target/debug && ln -sf libportability.$(LIB_EXTENSION) libvulkan.$(LIB_EXTENSION)

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ TEST_LIST_SOURCE=$(CTS_DIR)/external/vulkancts/mustpass/1.0.2/vk-default.txt
 DEQP_DIR=$(CTS_DIR)/build/external/vulkancts/modules/vulkan/
 DEQP=cd $(DEQP_DIR) && RUST_LOG=debug LD_LIBRARY_PATH=$(FULL_LIBRARY_PATH) ./deqp-vk
 CLINK_ARGS=
-COMMIT_SHA_SHORT=$(shell git rev-parse --short HEAD)
+GIT_TAG=$(shell git describe --abbrev=0 --tags)
 OS_NAME=
 
 DOTA_DIR=../dota2/bin/osx64
@@ -59,7 +59,7 @@ FULL_LIBRARY_PATH=$(CURDIR)/target/debug
 LIBRARY=target/debug/libportability.$(LIB_EXTENSION)
 LIBRARY_FAST=target/release/libportability.$(LIB_EXTENSION)
 
-.PHONY: all rebuild debug release version-debug version-release binding run-native cts clean cherry dota-debug dota-release dota-orig dota-bench-gfx dota-bench-orig dota-bench-gl
+.PHONY: all rebuild debug release version-debug version-release binding run-native cts clean cherry dota-debug dota-release dota-orig dota-bench-gfx dota-bench-orig dota-bench-gl package
 
 all: $(NATIVE_TARGET)
 
@@ -160,8 +160,8 @@ clean:
 	rm -f $(NATIVE_OBJECTS) $(NATIVE_TARGET) $(BINDING)
 	cargo clean
 
-package.zip: version-debug version-release
-	cd target && zip ../gfx-portability-$(OS_NAME)-$(COMMIT_SHA_SHORT).zip */libportability.$(LIB_EXTENSION) ../.git/refs/heads/master
+package: version-debug version-release
+	cd target && zip ../gfx-portability-$(OS_NAME)-$(GIT_TAG).zip */libportability.$(LIB_EXTENSION) ../.git/refs/heads/master
 
 target/debug/libvulkan.$(LIB_EXTENSION):
 	cd target/debug && ln -sf libportability.$(LIB_EXTENSION) libvulkan.$(LIB_EXTENSION)

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ TEST_LIST_SOURCE=$(CTS_DIR)/external/vulkancts/mustpass/1.0.2/vk-default.txt
 DEQP_DIR=$(CTS_DIR)/build/external/vulkancts/modules/vulkan/
 DEQP=cd $(DEQP_DIR) && RUST_LOG=debug LD_LIBRARY_PATH=$(FULL_LIBRARY_PATH) ./deqp-vk
 CLINK_ARGS=
+COMMIT_SHA_SHORT=$(shell git rev-parse --short HEAD)
+OS_NAME=
 
 DOTA_DIR=../dota2/bin/osx64
 DOTA_EXE=$(DOTA_DIR)/dota2.app/Contents/MacOS/dota2
@@ -34,12 +36,14 @@ ifeq ($(OS),Windows_NT)
 	LDFLAGS=
 	BACKEND=dx12
 	LIB_EXTENSION=dll
+	OS_NAME=windows
 else
 	UNAME_S:=$(shell uname -s)
 	ifeq ($(UNAME_S),Linux)
 		LDFLAGS=-lpthread -ldl -lm -lX11 -lxcb
 		BACKEND=vulkan
 		LIB_EXTENSION=so
+		OS_NAME=linux
 	endif
 	ifeq ($(UNAME_S),Darwin)
 		LDFLAGS=-lpthread -ldl -lm
@@ -47,6 +51,7 @@ else
 		DEBUGGER=rust-lldb --
 		LIB_EXTENSION=dylib
 		CLINK_ARGS=-- -Clink-arg="-current_version 1.0.0" -Clink-arg="-compatibility_version 1.0.0"
+		OS_NAME=macos
 	endif
 endif
 
@@ -156,7 +161,7 @@ clean:
 	cargo clean
 
 package.zip: version-debug version-release
-	zip package.zip target/*/libportability.$(LIB_EXTENSION) .git/refs/heads/master
+	cd target && zip ../gfx-portability-$(OS_NAME)-$(COMMIT_SHA_SHORT).zip */libportability.$(LIB_EXTENSION) ../.git/refs/heads/master
 
 target/debug/libvulkan.$(LIB_EXTENSION):
 	cd target/debug && ln -sf libportability.$(LIB_EXTENSION) libvulkan.$(LIB_EXTENSION)


### PR DESCRIPTION
Include OS name, use shorter commit SHA, and use a single level of directories for produced binaries.

The only potential downside about the commit SHA being included is that moving tags will cause the binaries to aggregate on the single release, see https://github.com/gfx-rs/portability/releases for example. Maybe this is a useful feature though, and we'll just need to clean releases up every once in a while.