### PR TITLE
Change deploy to overwrite existing release files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,7 @@ deploy:
   file_glob: true
   file: gfx-portability-*.zip
   skip_cleanup: true
+  overwrite: true
   on:
     tags: true
     condition: $TRAVIS_RUST_VERSION == "stable" && $TRAVIS_BRANCH == $TRAVIS_TAG


### PR DESCRIPTION
Small but important fix to resolve https://travis-ci.org/gfx-rs/portability/jobs/425115925#L1818

Earlier I bumped the `latest` tag with `git tag -a latest -f; and git push --tags -f` and it built and attempted to deploy successfully, but didn't upload the new files because of this.