### PR TITLE
Dependencies update, all-around unsafe qualifiers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,7 +3,7 @@ name = "aho-corasick"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "memchr 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -26,7 +26,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "approx"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "arrayvec"
-version = "0.4.8"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -42,11 +42,10 @@ dependencies = [
 
 [[package]]
 name = "ash"
-version = "0.24.4"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "shared_library 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -55,30 +54,36 @@ name = "atty"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.46 (registry+https://github.com/rust-lang/crates.io-index)",
  "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
+name = "autocfg"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "backtrace"
-version = "0.3.9"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace-sys 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-demangle 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.46 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-demangle 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "backtrace-sys"
-version = "0.1.24"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.46 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -98,7 +103,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cc"
-version = "1.0.25"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -112,7 +117,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gleam 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.46 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -131,7 +136,7 @@ dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.46 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -145,7 +150,7 @@ dependencies = [
  "core-foundation 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.46 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -155,7 +160,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "core-foundation-sys 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.46 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -164,7 +169,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "core-foundation-sys 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.46 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -172,7 +177,7 @@ name = "core-foundation-sys"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.46 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -188,7 +193,7 @@ dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.46 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -199,13 +204,13 @@ dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.46 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "d3d12"
 version = "0.1.0"
-source = "git+https://github.com/gfx-rs/d3d12-rs.git?rev=ee01154#ee0115462e4c3178e80454c11a34a458f9a326e7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -218,7 +223,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.24 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -248,21 +253,21 @@ dependencies = [
 
 [[package]]
 name = "failure"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "failure_derive"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -309,40 +314,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "gfx-backend-dx11"
 version = "0.1.0"
-source = "git+https://github.com/gfx-rs/gfx#389429e14319ee4994ab4ada3338a3b930046e4d"
+source = "git+https://github.com/gfx-rs/gfx#4f9945efb0d08685fa6edc56acf826fd3b5c39fe"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "derivative 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx-hal 0.1.0 (git+https://github.com/gfx-rs/gfx)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "range-alloc 0.1.0 (git+https://github.com/gfx-rs/gfx)",
  "smallvec 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "spirv_cross 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spirv_cross 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "winit 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winit 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "wio 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "gfx-backend-dx12"
 version = "0.1.0"
-source = "git+https://github.com/gfx-rs/gfx#389429e14319ee4994ab4ada3338a3b930046e4d"
+source = "git+https://github.com/gfx-rs/gfx#4f9945efb0d08685fa6edc56acf826fd3b5c39fe"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "d3d12 0.1.0 (git+https://github.com/gfx-rs/d3d12-rs.git?rev=ee01154)",
+ "d3d12 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "derivative 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx-hal 0.1.0 (git+https://github.com/gfx-rs/gfx)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "range-alloc 0.1.0 (git+https://github.com/gfx-rs/gfx)",
  "smallvec 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "spirv_cross 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spirv_cross 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "winit 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winit 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "gfx-backend-metal"
 version = "0.1.0"
-source = "git+https://github.com/gfx-rs/gfx#389429e14319ee4994ab4ada3338a3b930046e4d"
+source = "git+https://github.com/gfx-rs/gfx#4f9945efb0d08685fa6edc56acf826fd3b5c39fe"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -351,28 +358,29 @@ dependencies = [
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx-hal 0.1.0 (git+https://github.com/gfx-rs/gfx)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "metal 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "metal 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "range-alloc 0.1.0 (git+https://github.com/gfx-rs/gfx)",
  "smallvec 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "spirv_cross 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spirv_cross 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "storage-map 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "winit 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winit 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "gfx-backend-vulkan"
 version = "0.1.0"
-source = "git+https://github.com/gfx-rs/gfx#389429e14319ee4994ab4ada3338a3b930046e4d"
+source = "git+https://github.com/gfx-rs/gfx#4f9945efb0d08685fa6edc56acf826fd3b5c39fe"
 dependencies = [
- "ash 0.24.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ash 0.27.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx-hal 0.1.0 (git+https://github.com/gfx-rs/gfx)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "winit 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winit 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "x11 2.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "xcb 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -380,12 +388,11 @@ dependencies = [
 [[package]]
 name = "gfx-hal"
 version = "0.1.0"
-source = "git+https://github.com/gfx-rs/gfx#389429e14319ee4994ab4ada3338a3b930046e4d"
+source = "git+https://github.com/gfx-rs/gfx#4f9945efb0d08685fa6edc56acf826fd3b5c39fe"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -428,7 +435,7 @@ dependencies = [
  "core-graphics 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gl_generator 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.46 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "osmesa-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "shared_library 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -468,7 +475,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.44"
+version = "0.2.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -476,7 +483,7 @@ name = "libloading"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -510,16 +517,16 @@ name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.46 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.46 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -528,13 +535,22 @@ name = "memmap"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.46 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "memmap"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.46 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "metal"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -542,7 +558,7 @@ dependencies = [
  "cocoa 0.18.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.46 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc-foundation 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -551,13 +567,13 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.46 (registry+https://github.com/rust-lang/crates.io-index)",
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -640,12 +656,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking_lot"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "parking_lot_core"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.46 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.46 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -718,36 +755,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.46 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rand"
-version = "0.6.1"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_chacha 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.46 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_isaac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_os 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_pcg 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_xorshift 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "autocfg 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -780,6 +816,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_os"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.46 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rand_pcg"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -790,7 +839,20 @@ dependencies = [
 
 [[package]]
 name = "rand_xorshift"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "range-alloc"
 version = "0.1.0"
+source = "git+https://github.com/gfx-rs/gfx#4f9945efb0d08685fa6edc56acf826fd3b5c39fe"
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -798,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.43"
+version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -806,7 +868,7 @@ name = "redox_termios"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "redox_syscall 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.50 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -815,7 +877,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -852,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.9"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -868,10 +930,10 @@ name = "rusttype"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "approx 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "arrayvec 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "approx 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "ordered-float 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "stb_truetype 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stb_truetype 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -906,7 +968,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.46 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -919,27 +981,27 @@ dependencies = [
 
 [[package]]
 name = "smithay-client-toolkit"
-version = "0.4.2"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "andrew 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "dlib 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "memmap 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "nix 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-client 0.21.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-commons 0.21.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-protocols 0.21.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nix 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-client 0.21.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-commons 0.21.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-protocols 0.21.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "spirv_cross"
-version = "0.11.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -949,7 +1011,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "stb_truetype"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -965,7 +1027,7 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "0.15.22"
+version = "0.15.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -980,7 +1042,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -990,9 +1052,9 @@ version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.46 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1010,8 +1072,8 @@ name = "termion"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.46 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1077,7 +1139,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.46 (registry+https://github.com/rust-lang/crates.io-index)",
  "token_store 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-scanner 0.12.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-sys 0.12.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1085,25 +1147,25 @@ dependencies = [
 
 [[package]]
 name = "wayland-client"
-version = "0.21.7"
+version = "0.21.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "downcast-rs 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
- "nix 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-commons 0.21.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-scanner 0.21.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-sys 0.21.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.46 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nix 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-commons 0.21.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-scanner 0.21.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-sys 0.21.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wayland-commons"
-version = "0.21.7"
+version = "0.21.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "nix 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-sys 0.21.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nix 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-sys 0.21.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1131,14 +1193,14 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols"
-version = "0.21.7"
+version = "0.21.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-client 0.21.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-commons 0.21.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-scanner 0.21.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-sys 0.21.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-client 0.21.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-commons 0.21.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-scanner 0.21.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-sys 0.21.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1151,7 +1213,7 @@ dependencies = [
 
 [[package]]
 name = "wayland-scanner"
-version = "0.21.7"
+version = "0.21.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "xml-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1168,7 +1230,7 @@ dependencies = [
 
 [[package]]
 name = "wayland-sys"
-version = "0.21.7"
+version = "0.21.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dlib 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1232,7 +1294,7 @@ dependencies = [
  "core-foundation 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.46 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-client 0.12.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1245,21 +1307,22 @@ dependencies = [
 
 [[package]]
 name = "winit"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "android_glue 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "cocoa 0.18.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.46 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "smithay-client-toolkit 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-client 0.21.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smithay-client-toolkit 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-client 0.21.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "x11-dl 2.18.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1277,7 +1340,7 @@ name = "x11"
 version = "2.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.46 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1287,7 +1350,7 @@ version = "2.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.46 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1296,7 +1359,7 @@ name = "xcb"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.46 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1322,16 +1385,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1e9a933f4e58658d7b12defcf96dc5c720f20832deebe3e0a19efd3b6aaeeb9e"
 "checksum andrew 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "62ea7024f6f4d203bede7c0c9cdafa3cbda3a9e0fa04d349008496cc95b8f11b"
 "checksum android_glue 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "000444226fcff248f2bc4c7625be32c63caccfecc2723a2b9f78a7487a49c407"
-"checksum approx 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f71f10b5c4946a64aad7b8cf65e3406cd3da22fc448595991d22423cf6db67b4"
-"checksum arrayvec 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "f405cc4c21cd8b784f6c8fc2adf9bc00f59558f0049b5ec21517f875963040cc"
-"checksum ash 0.24.4 (registry+https://github.com/rust-lang/crates.io-index)" = "11f080bc0414ee1b6b959442cb36478d56c6e6b9bb2b04079a5048d9acc91a30"
+"checksum approx 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3c57ff1a5b00753647aebbbcf4ea67fa1e711a65ea7a30eb90dbf07de2485aee"
+"checksum arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "92c7fb76bc8826a8b33b4ee5bb07a247a81e76764ab4d55e8f73e3a4d8808c71"
+"checksum ash 0.27.0 (registry+https://github.com/rust-lang/crates.io-index)" = "18e1841348c170733919e7674ad09fc460ece970790959a1ae320df1735b330e"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
-"checksum backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "89a47830402e9981c5c41223151efcced65a0510c13097c769cede7efb34782a"
-"checksum backtrace-sys 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)" = "c66d56ac8dabd07f6aacdaf633f4b8262f5b3601a810a0dcddffd5c22c69daa0"
+"checksum autocfg 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4e5f34df7a019573fb8bdc7e24a2bfebe51a2a1d6bfdbaeccedb3c41fc574727"
+"checksum backtrace 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)" = "b5b493b66e03090ebc4343eb02f94ff944e0cbc9ac6571491d170ba026741eb5"
+"checksum backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "797c830ac25ccc92a7f8a7b9862bde440715531514594a6154e3d4a54dd769b6"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 "checksum byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "94f88df23a25417badc922ab0f5716cc1330e87f71ddd9203b3a3ccd9cedf75d"
-"checksum cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "f159dfd43363c4d08055a07703eb7a3406b0dac4d0584d96965a3262db3c9d16"
+"checksum cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4a8b715cb4597106ea87c7c84b2f1d452c7492033765df7f32651e66fcf749"
 "checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
 "checksum cgl 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "55e7ec0b74fe5897894cbc207092c577e87c52f8a59e8ca8d97ef37551f60a49"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
@@ -1343,13 +1407,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum core-foundation-sys 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b"
 "checksum core-graphics 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fb0ed45fdc32f9ab426238fba9407dfead7bacd7900c9b4dd3f396f46eafdae3"
 "checksum core-graphics 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)" = "56790968ab1c8a1202a102e6de05fc6e1ec87da99e4e93e9a7d13efbfc1e95a9"
-"checksum d3d12 0.1.0 (git+https://github.com/gfx-rs/d3d12-rs.git?rev=ee01154)" = "<none>"
+"checksum d3d12 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4fda5547c55c93b070d59108464bbfd7d9da9563b2ce78fceefc6430e972a420"
 "checksum derivative 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6073e9676dbebdddeabaeb63e3b7cefd23c86f5c41d381ee1237cc77b1079898"
 "checksum dlib 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "77e51249a9d823a4cb79e3eca6dcd756153e8ed0157b6c04775d04bf1b13b76a"
 "checksum downcast-rs 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "18df8ce4470c189d18aa926022da57544f31e154631eb4cfe796aea97051fe6c"
 "checksum env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)" = "15b0a4d2e39f8420210be8b27eeda28029729e2fd4291019455016c348240c38"
-"checksum failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6dd377bcc1b1b7ce911967e3ec24fa19c3224394ec05b54aa7b083d498341ac7"
-"checksum failure_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "64c2d913fe8ed3b6c6518eedf4538255b989945c14c2a7d5cbff62a5e2120596"
+"checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
+"checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 "checksum foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
@@ -1370,16 +1434,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum khronos_api 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "62237e6d326bd5871cd21469323bf096de81f1618cd82cbaf5d87825335aeb49"
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
 "checksum lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a374c89b9db55895453a74c1e38861d9deec0b01b405a82516e9d5de4820dea1"
-"checksum libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)" = "10923947f84a519a45c8fefb7dd1b3e8c08747993381adee176d7a82b4195311"
+"checksum libc 0.2.46 (registry+https://github.com/rust-lang/crates.io-index)" = "023a4cd09b2ff695f9734c1934145a315594b7986398496841c7031a5a1bbdbd"
 "checksum libloading 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3ad660d7cb8c5822cd83d10897b0f1f1526792737a179e73896152f85b88c2"
 "checksum line_drawing 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5cc7ad3d82c845bdb5dde34ffdcc7a5fb4d2996e1e1ee0f19c33bc80e15196b9"
 "checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
 "checksum malloc_buf 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
-"checksum memchr 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0a3eb002f0535929f1199681417029ebea04aadc0c7a4224b46be99c7f5d6a16"
+"checksum memchr 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "db4c41318937f6e76648f42826b1d9ade5c09cafb5aef7e351240a70f39206e9"
 "checksum memmap 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e2ffa2c986de11a9df78620c01eeaaf27d94d3ff02bf81bfcca953102dd0c6ff"
-"checksum metal 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8411e1b14691a658f4b285f980c98d1af1922dcf037ea4454288dc456ca0d1ed"
-"checksum nix 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d37e713a259ff641624b6cb20e3b12b2952313ba36b6823c0f16e6cfd9e5de17"
+"checksum memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
+"checksum metal 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cd3f21d259068945192293b7a98b1c6844af9eb7602e393c405198b229efc157"
+"checksum nix 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "921f61dc817b379d0834e45d5ec45beaacfae97082090a49c2cf30dcbc30206f"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
 "checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
 "checksum objc 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "9833ab0efe5361b1e2122a0544a5d3359576911a42cb098c2e59be8650807367"
@@ -1390,28 +1455,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum osmesa-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "88cfece6e95d2e717e0872a7f53a8684712ad13822a7979bc760b9c77ec0013b"
 "checksum owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
 "checksum parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f0802bff09003b291ba756dc7e79313e51cc31667e94afbe847def490424cde5"
+"checksum parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab41b4aed082705d1056416ae4468b6ea99d52599ecf3169b00088d43113e337"
 "checksum parking_lot_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad7f7e6ebdc79edff6fdcb87a55b620174f7a989e3eb31b65231f4af57f00b8c"
+"checksum parking_lot_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94c8c7923936b28d546dfd14d4472eaf34c99b14e1c973a32b3e6d4eb04298c9"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
 "checksum proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)" = "77619697826f31a02ae974457af0b29b723e5619e113e9397b8b82c6bd253f09"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "53fa22a1994bd0f9372d7a816207d8a2677ad0325b073f5c5332760f0fb62b5c"
 "checksum rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e464cd887e869cddcae8792a4ee31d23c7edd516700695608f5b98c67ee0131c"
-"checksum rand 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ae9d223d52ae411a33cf7e54ec6034ec165df296ccd23533d671a28252b6f66a"
-"checksum rand_chacha 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "771b009e3a508cb67e8823dda454aaa5368c7bc1c16829fb77d3e980440dd34a"
+"checksum rand 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3906503e80ac6cbcacb2c2973fa8e473f24d7e2747c8c92bb230c2441cad96b5"
+"checksum rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
 "checksum rand_core 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1961a422c4d189dfb50ffa9320bf1f2a9bd54ecb92792fb9477f99a1045f3372"
 "checksum rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0905b6b7079ec73b314d4c748701f6931eb79fd97c668caa3f1899b22b32c6db"
 "checksum rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
 "checksum rand_isaac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
+"checksum rand_os 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f46fbd5550acf75b0c2730f5dd1873751daf9beb8f11b44027778fae50d7feca"
 "checksum rand_pcg 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "086bd09a33c7044e56bb44d5bdde5a60e7f119a9e95b0775f545de759a32fe05"
-"checksum rand_xorshift 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "effa3fcaa47e18db002bdde6060944b6d2f9cfd8db471c30e873448ad9187be3"
-"checksum redox_syscall 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "679da7508e9a6390aeaf7fbd02a800fdc64b73fe2204dd2c8ae66d22d9d5ad5d"
+"checksum rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
+"checksum range-alloc 0.1.0 (git+https://github.com/gfx-rs/gfx)" = "<none>"
+"checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+"checksum redox_syscall 0.1.50 (registry+https://github.com/rust-lang/crates.io-index)" = "52ee9a534dc1301776eff45b4fa92d2c39b1d8c3d3357e6eb593e0d795506fc2"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "37e7cbbd370869ce2e8dff25c7018702d10b21a20ef7135316f8daecd6c25b7f"
 "checksum regex-syntax 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4e47a2ed29da7a9e1960e1639e7a982e6edc6d49be308a3b02daf511504a16d1"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
 "checksum renderdoc 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3aee9badfb4078c375d2d0479ed29c9c057b51ade78f94792ba2dcb11f343e7e"
-"checksum rustc-demangle 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "bcfe5b13211b4d78e5c2cadfebd7769197d95c639c35a50057eb4c05de811395"
+"checksum rustc-demangle 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "adacaae16d02b6ec37fdc7acfcddf365978de76d1983d3ee22afc260e1ca9619"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum rusttype 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "436c67ae0d0d24f14e1177c3ed96780ee16db82b405f0fba1bb80b46c9a30625"
 "checksum same-file 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8f20c4be53a8a1ff4c1f1b2bd14570d2f634628709752f0702ecdd2b3f9a5267"
@@ -1420,12 +1490,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum shared_library 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
 "checksum smallvec 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "b73ea3738b47563803ef814925e69be00799a8c07420be8b996f8e98fb2336db"
-"checksum smithay-client-toolkit 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ef227bd9251cf8f8e54f8dd9a4b164307e515f5312cd632ebc87b56f723893a2"
-"checksum spirv_cross 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2cc3aef2f7822a4fdd4174f547700f208bbc0f0871c59b754573717c92fd29f4"
+"checksum smithay-client-toolkit 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d858330eeed4efaf71c560555e2a6a0597d01b7d52685c3cc964ab1cc360f8c6"
+"checksum spirv_cross 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5c38f3b84da9c0439a5898f0697a07c8d59259b9d36c43e4fd5a9a01c38cd80a"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
-"checksum stb_truetype 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "48fa7d3136d8645909de1f7c7eb5416cc43057a75ace08fc39ae736bc9da8af1"
+"checksum stb_truetype 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "71a7d260b43b6129a22dc341be18a231044ca67a48b7e32625f380cc5ec9ad70"
 "checksum storage-map 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "cb94f167ccba0941876c8e722e888be8b4c05511ffdacc8cfcd4c647adfd424d"
-"checksum syn 0.15.22 (registry+https://github.com/rust-lang/crates.io-index)" = "ae8b29eb5210bc5cf63ed6149cbf9adfc82ac0be023d8735c176ee74a2db4da7"
+"checksum syn 0.15.24 (registry+https://github.com/rust-lang/crates.io-index)" = "734ecc29cd36e8123850d9bf21dfd62ef8300aaa8f879aabaa899721808be37c"
 "checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
 "checksum tempfile 3.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "7e91405c14320e5c79b3d148e1c86f40749a36e490642202a31689cb1a3452b2"
 "checksum termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4096add70612622289f2fdcdbd5086dc81c1e2675e6ae58d6c4f62a16c6d7f2f"
@@ -1440,15 +1510,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "9d9d7ed3431229a144296213105a390676cc49c9b6a72bd19f3176c98e129fa1"
 "checksum wayland-client 0.12.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2b90adf943117ee4930d7944fe103dcb6f36ba05421f46521cb5adbf6bf0fbc8"
-"checksum wayland-client 0.21.7 (registry+https://github.com/rust-lang/crates.io-index)" = "267d642a6e551e5af62a5e4fbfaab299221e6ddbd453b5985cfa84c835887679"
-"checksum wayland-commons 0.21.7 (registry+https://github.com/rust-lang/crates.io-index)" = "da95f98e6b8222cb0f248811ecd69ba6ebe243b737fd34020f7c73665bb4a3af"
+"checksum wayland-client 0.21.10 (registry+https://github.com/rust-lang/crates.io-index)" = "cb4e519a7a979ddf97ee25c07830bd10b2c466b3b904b8ad4a05b4eee58c1a4e"
+"checksum wayland-commons 0.21.10 (registry+https://github.com/rust-lang/crates.io-index)" = "d985937818df10af90fe61bf8fc520fc6179539d972378b78be773694bb9f432"
 "checksum wayland-kbd 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4fe0fb1c9917da9529d781659e456d84a693d74fe873d1658109758444616f76"
 "checksum wayland-protocols 0.12.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fb5942dd2fc79d934db437c9ea3aabffceb49b546046ea453bcba531005e5537"
-"checksum wayland-protocols 0.21.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a1d20e951995113cdb8f32578c8402e619aa3d3e894f3ca334deb219abc1f6df"
+"checksum wayland-protocols 0.21.10 (registry+https://github.com/rust-lang/crates.io-index)" = "e634e68e5b759cb549410ae1f25aab3c77cdc8f861aed9d0e86c2bd74efcb086"
 "checksum wayland-scanner 0.12.5 (registry+https://github.com/rust-lang/crates.io-index)" = "dcffa55a621e6f2c3d436de64d840fc325e1d0a467b92ee5e7292e17552e08ad"
-"checksum wayland-scanner 0.21.7 (registry+https://github.com/rust-lang/crates.io-index)" = "4f17846a40a19f7917f11c18a6c8c3b3a34b3ba09cb200d3e03503ebdfcbf3a7"
+"checksum wayland-scanner 0.21.10 (registry+https://github.com/rust-lang/crates.io-index)" = "1c8b867a824057b856790776e7cee37daf0435fc06543f2d96b2e37d15322e99"
 "checksum wayland-sys 0.12.5 (registry+https://github.com/rust-lang/crates.io-index)" = "377a2f83063c463e801ca10ae8cb9666e6e597eecac0049ac36cc7b9a83b0db3"
-"checksum wayland-sys 0.21.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a0931c24c91e4e56c1119e4137e237df2ccc3696df94f64b1e2f61982d89cc32"
+"checksum wayland-sys 0.21.10 (registry+https://github.com/rust-lang/crates.io-index)" = "6807f24ccb5b1a76a854fbd18160ae11cea64717b2f643d10810e5ef7fba2f59"
 "checksum wayland-window 0.13.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e5bf431e84f0de9cd06a30b2fb9ab9458f449cb6c36277da703e979ad5c141b1"
 "checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
@@ -1456,7 +1526,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 "checksum wincolor 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "561ed901ae465d6185fa7864d63fbd5720d0ef718366c9a4dc83cf6170d7e9ba"
 "checksum winit 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3706b5ba299cc9ed06d39b8021fc5edd5a7d27d8e99355ca09636fddd9b14cc0"
-"checksum winit 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)" = "27aa86a5723951d6a08c2acb9f10e25cb39ceb5b1987d7daf74e181b21f8f50b"
+"checksum winit 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c57c15bd4c0ef18dff33e263e452abe32d00e2e05771cacaa410a14cc1c0776"
 "checksum wio 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8a31e8a268d6941ffb7f8d7989fc93e4692bd3e75a27d400a72b4be1dadb213"
 "checksum x11 2.18.1 (registry+https://github.com/rust-lang/crates.io-index)" = "39697e3123f715483d311b5826e254b6f3cfebdd83cf7ef3358f579c3d68e235"
 "checksum x11-dl 2.18.3 (registry+https://github.com/rust-lang/crates.io-index)" = "940586acb859ea05c53971ac231685799a7ec1dee66ac0bccc0e6ad96e06b4e3"

--- a/libportability-gfx/src/conv.rs
+++ b/libportability-gfx/src/conv.rs
@@ -553,6 +553,24 @@ pub fn map_present_mode(present_mode: VkPresentModeKHR) -> window::PresentMode {
     unsafe { mem::transmute(present_mode) }
 }
 
+pub fn map_composite_alpha(composite_alpha: VkCompositeAlphaFlagBitsKHR) -> window::CompositeAlpha {
+    if composite_alpha == VkCompositeAlphaFlagBitsKHR::VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR {
+        window::CompositeAlpha::Opaque
+    } else
+    if composite_alpha == VkCompositeAlphaFlagBitsKHR::VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR {
+        window::CompositeAlpha::PreMultiplied
+    } else
+    if composite_alpha == VkCompositeAlphaFlagBitsKHR::VK_COMPOSITE_ALPHA_POST_MULTIPLIED_BIT_KHR {
+        window::CompositeAlpha::PostMultiplied
+    } else
+    if composite_alpha == VkCompositeAlphaFlagBitsKHR::VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR {
+        window::CompositeAlpha::Inherit
+    } else {
+        error!("Unrecognized composite alpha: {:?}", composite_alpha);
+        window::CompositeAlpha::Opaque
+    }
+}
+
 #[inline]
 pub fn map_present_mode_from_hal(present_mode: window::PresentMode) -> VkPresentModeKHR {
     // Vulkan and HAL values are equal

--- a/libportability-gfx/src/impls.rs
+++ b/libportability-gfx/src/impls.rs
@@ -257,8 +257,8 @@ pub extern "C" fn gfxGetPhysicalDeviceFeatures(
             shaderResourceMinLod: features.contains(Features::SHADER_RESOURCE_MIN_LOD) as _,
             sparseBinding: features.contains(Features::SPARSE_BINDING) as _,
             sparseResidencyBuffer: features.contains(Features::SPARSE_RESIDENCY_BUFFER) as _,
-            sparseResidencyImage2D: features.contains(Features::SHADER_RESIDENCY_IMAGE_2D) as _,
-            sparseResidencyImage3D: features.contains(Features::SHADER_RESIDENSY_IMAGE_3D) as _,
+            sparseResidencyImage2D: features.contains(Features::SPARSE_RESIDENCY_IMAGE_2D) as _,
+            sparseResidencyImage3D: features.contains(Features::SPARSE_RESIDENCY_IMAGE_3D) as _,
             sparseResidency2Samples: features.contains(Features::SPARSE_RESIDENCY_2_SAMPLES) as _,
             sparseResidency4Samples: features.contains(Features::SPARSE_RESIDENCY_4_SAMPLES) as _,
             sparseResidency8Samples: features.contains(Features::SPARSE_RESIDENCY_8_SAMPLES) as _,
@@ -623,66 +623,68 @@ pub extern "C" fn gfxCreateDevice(
         })
         .collect::<Vec<_>>();
 
-    if let Some(ef) = unsafe { dev_info.pEnabledFeatures.as_ref() } {
-        let supported = adapter.physical_device.features();
-        if (ef.robustBufferAccess != 0 && !supported.contains(Features::ROBUST_BUFFER_ACCESS)) ||
-            (ef.fullDrawIndexUint32 != 0 && !supported.contains(Features::FULL_DRAW_INDEX_U32)) ||
-            (ef.imageCubeArray != 0 && !supported.contains(Features::IMAGE_CUBE_ARRAY)) ||
-            (ef.independentBlend != 0 && !supported.contains(Features::INDEPENDENT_BLENDING)) ||
-            (ef.geometryShader != 0 && !supported.contains(Features::GEOMETRY_SHADER)) ||
-            (ef.tessellationShader != 0 && !supported.contains(Features::TESSELLATION_SHADER)) ||
-            (ef.sampleRateShading != 0 && !supported.contains(Features::SAMPLE_RATE_SHADING)) ||
-            (ef.dualSrcBlend != 0 && !supported.contains(Features::DUAL_SRC_BLENDING)) ||
-            (ef.logicOp != 0 && !supported.contains(Features::LOGIC_OP)) ||
-            (ef.multiDrawIndirect != 0 && !supported.contains(Features::MULTI_DRAW_INDIRECT)) ||
-            (ef.drawIndirectFirstInstance != 0 && !supported.contains(Features::DRAW_INDIRECT_FIRST_INSTANCE)) ||
-            (ef.depthClamp != 0 && !supported.contains(Features::DEPTH_CLAMP)) ||
-            (ef.depthBiasClamp != 0 && !supported.contains(Features::DEPTH_BIAS_CLAMP)) ||
-            (ef.fillModeNonSolid != 0 && !supported.contains(Features::NON_FILL_POLYGON_MODE)) ||
-            (ef.depthBounds != 0 && !supported.contains(Features::DEPTH_BOUNDS)) ||
-            (ef.wideLines != 0 && !supported.contains(Features::LINE_WIDTH)) ||
-            (ef.largePoints != 0 && !supported.contains(Features::POINT_SIZE)) ||
-            (ef.alphaToOne != 0 && !supported.contains(Features::ALPHA_TO_ONE)) ||
-            (ef.multiViewport != 0 && !supported.contains(Features::MULTI_VIEWPORTS)) ||
-            (ef.samplerAnisotropy != 0 && !supported.contains(Features::SAMPLER_ANISOTROPY)) ||
-            (ef.textureCompressionETC2 != 0 && !supported.contains(Features::FORMAT_ETC2)) ||
-            (ef.textureCompressionASTC_LDR != 0 && !supported.contains(Features::FORMAT_ASTC_LDR)) ||
-            (ef.textureCompressionBC != 0 && !supported.contains(Features::FORMAT_BC)) ||
-            (ef.occlusionQueryPrecise != 0 && !supported.contains(Features::PRECISE_OCCLUSION_QUERY)) ||
-            (ef.pipelineStatisticsQuery != 0 && !supported.contains(Features::PIPELINE_STATISTICS_QUERY)) ||
-            (ef.vertexPipelineStoresAndAtomics != 0 && !supported.contains(Features::VERTEX_STORES_AND_ATOMICS)) ||
-            (ef.fragmentStoresAndAtomics != 0 && !supported.contains(Features::FRAGMENT_STORES_AND_ATOMICS)) ||
-            (ef.shaderTessellationAndGeometryPointSize != 0 && !supported.contains(Features::SHADER_TESSELLATION_AND_GEOMETRY_POINT_SIZE)) ||
-            (ef.shaderImageGatherExtended != 0 && !supported.contains(Features::SHADER_IMAGE_GATHER_EXTENDED)) ||
-            (ef.shaderStorageImageExtendedFormats != 0 && !supported.contains(Features::SHADER_STORAGE_IMAGE_EXTENDED_FORMATS)) ||
-            (ef.shaderStorageImageMultisample != 0 && !supported.contains(Features::SHADER_STORAGE_IMAGE_MULTISAMPLE)) ||
-            (ef.shaderStorageImageReadWithoutFormat != 0 && !supported.contains(Features::SHADER_STORAGE_IMAGE_READ_WITHOUT_FORMAT)) ||
-            (ef.shaderStorageImageWriteWithoutFormat != 0 && !supported.contains(Features::SHADER_STORAGE_IMAGE_WRITE_WITHOUT_FORMAT)) ||
-            (ef.shaderUniformBufferArrayDynamicIndexing != 0 && !supported.contains(Features::SHADER_UNIFORM_BUFFER_ARRAY_DYNAMIC_INDEXING)) ||
-            (ef.shaderSampledImageArrayDynamicIndexing != 0 && !supported.contains(Features::SHADER_SAMPLED_IMAGE_ARRAY_DYNAMIC_INDEXING)) ||
-            (ef.shaderStorageBufferArrayDynamicIndexing != 0 && !supported.contains(Features::SHADER_STORAGE_BUFFER_ARRAY_DYNAMIC_INDEXING)) ||
-            (ef.shaderStorageImageArrayDynamicIndexing != 0 && !supported.contains(Features::SHADER_STORAGE_IMAGE_ARRAY_DYNAMIC_INDEXING)) ||
-            (ef.shaderClipDistance != 0 && !supported.contains(Features::SHADER_CLIP_DISTANCE)) ||
-            (ef.shaderCullDistance != 0 && !supported.contains(Features::SHADER_CULL_DISTANCE)) ||
-            (ef.shaderFloat64 != 0 && !supported.contains(Features::SHADER_FLOAT64)) ||
-            (ef.shaderInt64 != 0 && !supported.contains(Features::SHADER_INT64)) ||
-            (ef.shaderInt16 != 0 && !supported.contains(Features::SHADER_INT16)) ||
-            (ef.shaderResourceResidency != 0 && !supported.contains(Features::SHADER_RESOURCE_RESIDENCY)) ||
-            (ef.shaderResourceMinLod != 0 && !supported.contains(Features::SHADER_RESOURCE_MIN_LOD)) ||
-            (ef.sparseBinding != 0 && !supported.contains(Features::SPARSE_BINDING)) ||
-            (ef.sparseResidencyBuffer != 0 && !supported.contains(Features::SPARSE_RESIDENCY_BUFFER)) ||
-            (ef.sparseResidencyImage2D != 0 && !supported.contains(Features::SHADER_RESIDENCY_IMAGE_2D)) ||
-            (ef.sparseResidencyImage3D != 0 && !supported.contains(Features::SHADER_RESIDENSY_IMAGE_3D)) ||
-            (ef.sparseResidency2Samples != 0 && !supported.contains(Features::SPARSE_RESIDENCY_2_SAMPLES)) ||
-            (ef.sparseResidency4Samples != 0 && !supported.contains(Features::SPARSE_RESIDENCY_4_SAMPLES)) ||
-            (ef.sparseResidency8Samples != 0 && !supported.contains(Features::SPARSE_RESIDENCY_8_SAMPLES)) ||
-            (ef.sparseResidency16Samples != 0 && !supported.contains(Features::SPARSE_RESIDENCY_16_SAMPLES)) ||
-            (ef.sparseResidencyAliased != 0 && !supported.contains(Features::SPARSE_RESIDENCY_ALIASED)) ||
-            (ef.variableMultisampleRate != 0 && !supported.contains(Features::VARIABLE_MULTISAMPLE_RATE)) ||
-            (ef.inheritedQueries != 0 && !supported.contains(Features::INHERITED_QUERIES)) {
-            return VkResult::VK_ERROR_FEATURE_NOT_PRESENT;
+    let enabled = if let Some(ef) = unsafe { dev_info.pEnabledFeatures.as_ref() } {
+        fn feat(on: u32, flag: Features) -> Features {
+            if on != 0 { flag } else { Features::empty() }
         }
-    }
+        feat(ef.robustBufferAccess, Features::ROBUST_BUFFER_ACCESS) |
+        feat(ef.fullDrawIndexUint32, Features::FULL_DRAW_INDEX_U32) |
+        feat(ef.imageCubeArray, Features::IMAGE_CUBE_ARRAY) |
+        feat(ef.independentBlend, Features::INDEPENDENT_BLENDING) |
+        feat(ef.geometryShader, Features::GEOMETRY_SHADER) |
+        feat(ef.tessellationShader, Features::TESSELLATION_SHADER) |
+        feat(ef.sampleRateShading, Features::SAMPLE_RATE_SHADING) |
+        feat(ef.dualSrcBlend, Features::DUAL_SRC_BLENDING) |
+        feat(ef.logicOp, Features::LOGIC_OP) |
+        feat(ef.multiDrawIndirect, Features::MULTI_DRAW_INDIRECT) |
+        feat(ef.drawIndirectFirstInstance, Features::DRAW_INDIRECT_FIRST_INSTANCE) |
+        feat(ef.depthClamp, Features::DEPTH_CLAMP) |
+        feat(ef.depthBiasClamp, Features::DEPTH_BIAS_CLAMP) |
+        feat(ef.fillModeNonSolid, Features::NON_FILL_POLYGON_MODE) |
+        feat(ef.depthBounds, Features::DEPTH_BOUNDS) |
+        feat(ef.wideLines, Features::LINE_WIDTH) |
+        feat(ef.largePoints, Features::POINT_SIZE) |
+        feat(ef.alphaToOne, Features::ALPHA_TO_ONE) |
+        feat(ef.multiViewport, Features::MULTI_VIEWPORTS) |
+        feat(ef.samplerAnisotropy, Features::SAMPLER_ANISOTROPY) |
+        feat(ef.textureCompressionETC2, Features::FORMAT_ETC2) |
+        feat(ef.textureCompressionASTC_LDR, Features::FORMAT_ASTC_LDR) |
+        feat(ef.textureCompressionBC, Features::FORMAT_BC) |
+        feat(ef.occlusionQueryPrecise, Features::PRECISE_OCCLUSION_QUERY) |
+        feat(ef.pipelineStatisticsQuery, Features::PIPELINE_STATISTICS_QUERY) |
+        feat(ef.vertexPipelineStoresAndAtomics, Features::VERTEX_STORES_AND_ATOMICS) |
+        feat(ef.fragmentStoresAndAtomics, Features::FRAGMENT_STORES_AND_ATOMICS) |
+        feat(ef.shaderTessellationAndGeometryPointSize, Features::SHADER_TESSELLATION_AND_GEOMETRY_POINT_SIZE) |
+        feat(ef.shaderImageGatherExtended, Features::SHADER_IMAGE_GATHER_EXTENDED) |
+        feat(ef.shaderStorageImageExtendedFormats, Features::SHADER_STORAGE_IMAGE_EXTENDED_FORMATS) |
+        feat(ef.shaderStorageImageMultisample, Features::SHADER_STORAGE_IMAGE_MULTISAMPLE) |
+        feat(ef.shaderStorageImageReadWithoutFormat, Features::SHADER_STORAGE_IMAGE_READ_WITHOUT_FORMAT) |
+        feat(ef.shaderStorageImageWriteWithoutFormat, Features::SHADER_STORAGE_IMAGE_WRITE_WITHOUT_FORMAT) |
+        feat(ef.shaderUniformBufferArrayDynamicIndexing, Features::SHADER_UNIFORM_BUFFER_ARRAY_DYNAMIC_INDEXING) |
+        feat(ef.shaderSampledImageArrayDynamicIndexing, Features::SHADER_SAMPLED_IMAGE_ARRAY_DYNAMIC_INDEXING) |
+        feat(ef.shaderStorageBufferArrayDynamicIndexing, Features::SHADER_STORAGE_BUFFER_ARRAY_DYNAMIC_INDEXING) |
+        feat(ef.shaderStorageImageArrayDynamicIndexing, Features::SHADER_STORAGE_IMAGE_ARRAY_DYNAMIC_INDEXING) |
+        feat(ef.shaderClipDistance, Features::SHADER_CLIP_DISTANCE) |
+        feat(ef.shaderCullDistance, Features::SHADER_CULL_DISTANCE) |
+        feat(ef.shaderFloat64, Features::SHADER_FLOAT64) |
+        feat(ef.shaderInt64, Features::SHADER_INT64) |
+        feat(ef.shaderInt16, Features::SHADER_INT16) |
+        feat(ef.shaderResourceResidency, Features::SHADER_RESOURCE_RESIDENCY) |
+        feat(ef.shaderResourceMinLod, Features::SHADER_RESOURCE_MIN_LOD) |
+        feat(ef.sparseBinding, Features::SPARSE_BINDING) |
+        feat(ef.sparseResidencyBuffer, Features::SPARSE_RESIDENCY_BUFFER) |
+        feat(ef.sparseResidencyImage2D, Features::SPARSE_RESIDENCY_IMAGE_2D) |
+        feat(ef.sparseResidencyImage3D, Features::SPARSE_RESIDENCY_IMAGE_3D) |
+        feat(ef.sparseResidency2Samples, Features::SPARSE_RESIDENCY_2_SAMPLES) |
+        feat(ef.sparseResidency4Samples, Features::SPARSE_RESIDENCY_4_SAMPLES) |
+        feat(ef.sparseResidency8Samples, Features::SPARSE_RESIDENCY_8_SAMPLES) |
+        feat(ef.sparseResidency16Samples, Features::SPARSE_RESIDENCY_16_SAMPLES) |
+        feat(ef.sparseResidencyAliased, Features::SPARSE_RESIDENCY_ALIASED) |
+        feat(ef.variableMultisampleRate, Features::VARIABLE_MULTISAMPLE_RATE) |
+        feat(ef.inheritedQueries, Features::INHERITED_QUERIES)
+    } else {
+        Features::empty()
+    };
 
     #[cfg(feature = "renderdoc")]
     let mut renderdoc = {
@@ -690,7 +692,9 @@ pub extern "C" fn gfxCreateDevice(
         RenderDoc::new().expect("Failed to init renderdoc")
     };
 
-    let gpu = adapter.physical_device.open(&request_infos);
+    let gpu = unsafe {
+        adapter.physical_device.open(&request_infos, enabled)
+    };
 
     match gpu {
         Ok(mut gpu) => {
@@ -1007,22 +1011,20 @@ pub extern "C" fn gfxQueueSubmit(
         stages.into_iter()
             .zip(semaphores)
             .map(|(stage, semaphore)| (&**semaphore, conv::map_pipeline_stage_flags(*stage)))
-            .collect::<Vec<_>>()
     };
     let signal_semaphores = unsafe {
         slice::from_raw_parts(submission.pSignalSemaphores, submission.signalSemaphoreCount as _)
             .into_iter()
             .map(|semaphore| &**semaphore)
-            .collect::<Vec<_>>()
     };
 
-    let submission = hal::queue::RawSubmission {
-        cmd_buffers: cmd_slice.iter().cloned(),
-        wait_semaphores: &wait_semaphores,
-        signal_semaphores: &signal_semaphores,
+    let submission = hal::queue::Submission {
+        command_buffers: cmd_slice.iter(),
+        wait_semaphores: wait_semaphores,
+        signal_semaphores: signal_semaphores,
     };
 
-    unsafe { queue.submit_raw(submission, fence.as_ref()); }
+    unsafe { queue.submit(submission, fence.as_ref()); }
 
     VkResult::VK_SUCCESS
 }
@@ -1043,15 +1045,15 @@ pub extern "C" fn gfxAllocateMemory(
     _pAllocator: *const VkAllocationCallbacks,
     pMemory: *mut VkDeviceMemory,
 ) -> VkResult {
-    let info = unsafe { &*pAllocateInfo };
-    let memory = gpu.device
-        .allocate_memory(
-            hal::MemoryTypeId(info.memoryTypeIndex as _),
-            info.allocationSize,
-        )
-        .unwrap(); // TODO:
-
     unsafe {
+        let info = &*pAllocateInfo;
+        let memory = gpu.device
+            .allocate_memory(
+                hal::MemoryTypeId(info.memoryTypeIndex as _),
+                info.allocationSize,
+            )
+            .unwrap(); // TODO:
+
         *pMemory = Handle::new(memory);
     }
     VkResult::VK_SUCCESS
@@ -1063,7 +1065,9 @@ pub extern "C" fn gfxFreeMemory(
     _pAllocator: *const VkAllocationCallbacks,
 ) {
     if let Some(mem) = memory.unbox() {
-        gpu.device.free_memory(mem);
+        unsafe {
+            gpu.device.free_memory(mem);
+        }
     }
 }
 #[inline]
@@ -1091,7 +1095,9 @@ pub extern "C" fn gfxMapMemory(
 }
 #[inline]
 pub extern "C" fn gfxUnmapMemory(gpu: VkDevice, memory: VkDeviceMemory) {
-    gpu.device.unmap_memory(&memory);
+    unsafe {
+        gpu.device.unmap_memory(&memory);
+    }
 }
 #[inline]
 pub extern "C" fn gfxFlushMappedMemoryRanges(
@@ -1113,7 +1119,9 @@ pub extern "C" fn gfxFlushMappedMemoryRanges(
             (&*r.memory, range)
         });
 
-    match gpu.device.flush_mapped_memory_ranges(ranges) {
+    match unsafe {
+        gpu.device.flush_mapped_memory_ranges(ranges)
+    } {
         Ok(()) => VkResult::VK_SUCCESS,
         Err(oom) => map_oom(oom),
     }
@@ -1138,7 +1146,9 @@ pub extern "C" fn gfxInvalidateMappedMemoryRanges(
             (&*r.memory, range)
         });
 
-    match gpu.device.invalidate_mapped_memory_ranges(ranges) {
+    match unsafe {
+        gpu.device.invalidate_mapped_memory_ranges(ranges)
+    } {
         Ok(()) => VkResult::VK_SUCCESS,
         Err(oom) => map_oom(oom),
     }
@@ -1158,22 +1168,11 @@ pub extern "C" fn gfxBindBufferMemory(
     memory: VkDeviceMemory,
     memoryOffset: VkDeviceSize,
 ) -> VkResult {
-    let new = match mem::replace(&mut *buffer, unsafe { mem::zeroed() }) {
-        Buffer::Buffer(_) => panic!("A non-sparse buffer can only be bound once!"),
-        Buffer::Unbound(unbound) => {
-            Buffer::Buffer(
-                gpu.device
-                    .bind_buffer_memory(&memory, memoryOffset, unbound)
-                    .unwrap() // TODO
-            )
-        }
-    };
-
-    // We need to move the value out of the Handle here,
-    // and then put something else back in.
-    let temp = mem::replace(&mut *buffer, new);
-    mem::forget(temp);
-
+    unsafe {
+        gpu.device
+            .bind_buffer_memory(&memory, memoryOffset, &mut *buffer)
+            .unwrap(); //TODO
+    }
     VkResult::VK_SUCCESS
 }
 #[inline]
@@ -1183,22 +1182,11 @@ pub extern "C" fn gfxBindImageMemory(
     memory: VkDeviceMemory,
     memoryOffset: VkDeviceSize,
 ) -> VkResult {
-    let new = match mem::replace(&mut *image, unsafe { mem::zeroed() }) {
-        Image::Image { .. } => panic!("An non-sparse image can only be bound once!"),
-        Image::Unbound { raw, mip_levels, array_layers } => {
-            Image::Image {
-                raw: gpu.device.bind_image_memory(&memory, memoryOffset, raw).unwrap(), // TODO
-                mip_levels,
-                array_layers,
-            }
-        }
-    };
-
-    // We need to move the value out of the Handle here,
-    // and then put something else back in.
-    let temp = mem::replace(&mut *image, new);
-    mem::forget(temp);
-
+    unsafe {
+        gpu.device
+            .bind_image_memory(&memory, memoryOffset, &mut image.raw)
+            .unwrap(); //TODO
+    }
     VkResult::VK_SUCCESS
 }
 #[inline]
@@ -1207,9 +1195,8 @@ pub extern "C" fn gfxGetBufferMemoryRequirements(
     buffer: VkBuffer,
     pMemoryRequirements: *mut VkMemoryRequirements,
 ) {
-    let req = match *buffer {
-        Buffer::Buffer(_) => unimplemented!(),
-        Buffer::Unbound(ref buffer) => gpu.device.get_buffer_requirements(buffer),
+    let req = unsafe {
+        gpu.device.get_buffer_requirements(&*buffer)
     };
 
     *unsafe { &mut *pMemoryRequirements } = VkMemoryRequirements {
@@ -1224,9 +1211,8 @@ pub extern "C" fn gfxGetImageMemoryRequirements(
     image: VkImage,
     pMemoryRequirements: *mut VkMemoryRequirements,
 ) {
-    let req = match *image {
-        Image::Image { .. } => unimplemented!(),
-        Image::Unbound { ref raw, .. } => gpu.device.get_image_requirements(raw),
+    let req = unsafe {
+        gpu.device.get_image_requirements(&image.raw)
     };
 
     *unsafe { &mut *pMemoryRequirements } = VkMemoryRequirements {
@@ -1295,7 +1281,9 @@ pub extern "C" fn gfxDestroyFence(
     _pAllocator: *const VkAllocationCallbacks,
 ) {
     if let Some(fence) = fence.unbox() {
-        gpu.device.destroy_fence(fence);
+        unsafe {
+            gpu.device.destroy_fence(fence);
+        }
     }
 }
 #[inline]
@@ -1311,14 +1299,18 @@ pub extern "C" fn gfxResetFences(
         .into_iter()
         .map(|fence| &**fence);
 
-    match gpu.device.reset_fences(fences) {
+    match unsafe {
+        gpu.device.reset_fences(fences)
+    } {
         Ok(()) => VkResult::VK_SUCCESS,
         Err(oom) => map_oom(oom),
     }
 }
 #[inline]
 pub extern "C" fn gfxGetFenceStatus(gpu: VkDevice, fence: VkFence) -> VkResult {
-    match gpu.device.get_fence_status(&*fence) {
+    match unsafe {
+        gpu.device.get_fence_status(&*fence)
+    } {
         Ok(true) => VkResult::VK_SUCCESS,
         Ok(false) => VkResult::VK_NOT_READY,
         Err(hal::device::DeviceLost) => VkResult::VK_ERROR_DEVICE_LOST,
@@ -1344,7 +1336,9 @@ pub extern "C" fn gfxWaitForFences(
         _ => WaitFor::All,
     };
 
-    match gpu.device.wait_for_fences(fences, wait_for, timeout as _) {
+    match unsafe {
+        gpu.device.wait_for_fences(fences, wait_for, timeout as _)
+    } {
         Ok(true) => VkResult::VK_SUCCESS,
         Ok(false) => VkResult::VK_TIMEOUT,
         Err(hal::device::OomOrDeviceLost::OutOfMemory(oom)) => map_oom(oom),
@@ -1375,7 +1369,9 @@ pub extern "C" fn gfxDestroySemaphore(
     _pAllocator: *const VkAllocationCallbacks,
 ) {
     if let Some(sem) = semaphore.unbox() {
-        gpu.device.destroy_semaphore(sem);
+        unsafe {
+            gpu.device.destroy_semaphore(sem);
+        }
     }
 }
 #[inline]
@@ -1418,11 +1414,13 @@ pub extern "C" fn gfxCreateQueryPool(
     _pAllocator: *const VkAllocationCallbacks,
     pQueryPool: *mut VkQueryPool,
 ) -> VkResult {
-    let info = unsafe { &*pCreateInfo };
-    let pool = gpu.device.create_query_pool(
-        conv::map_query_type(info.queryType, info.pipelineStatistics),
-        info.queryCount,
-    );
+    let pool = unsafe {
+        let info = &*pCreateInfo;
+        gpu.device.create_query_pool(
+            conv::map_query_type(info.queryType, info.pipelineStatistics),
+            info.queryCount,
+        )
+    };
 
     match pool {
         Ok(pool) => {
@@ -1442,7 +1440,9 @@ pub extern "C" fn gfxDestroyQueryPool(
     _pAllocator: *const VkAllocationCallbacks,
 ) {
     if let Some(pool) = queryPool.unbox() {
-        gpu.device.destroy_query_pool(pool);
+        unsafe {
+            gpu.device.destroy_query_pool(pool);
+        }
     }
 }
 #[inline]
@@ -1456,13 +1456,15 @@ pub extern "C" fn gfxGetQueryPoolResults(
     stride: VkDeviceSize,
     flags: VkQueryResultFlags,
 ) -> VkResult {
-    let result = gpu.device.get_query_pool_results(
-        &*queryPool,
-        firstQuery .. firstQuery + queryCount,
-        unsafe { slice::from_raw_parts_mut(pData as *mut u8, dataSize) },
-        stride,
-        conv::map_query_result(flags),
-    );
+    let result = unsafe {
+        gpu.device.get_query_pool_results(
+            &*queryPool,
+            firstQuery .. firstQuery + queryCount,
+            slice::from_raw_parts_mut(pData as *mut u8, dataSize),
+            stride,
+            conv::map_query_result(flags),
+        )
+    };
     match result {
         Ok(true) => VkResult::VK_SUCCESS,
         Ok(false) => VkResult::VK_NOT_READY,
@@ -1480,13 +1482,12 @@ pub extern "C" fn gfxCreateBuffer(
     assert_eq!(info.sharingMode, VkSharingMode::VK_SHARING_MODE_EXCLUSIVE); // TODO
     assert_eq!(info.flags, 0); // TODO
 
-    let buffer = gpu.device
-        .create_buffer(info.size, conv::map_buffer_usage(info.usage))
-        .expect("Error on creating buffer");
-
     unsafe {
-        *pBuffer = Handle::new(Buffer::Unbound(buffer));
-    }
+        let buffer = gpu.device
+            .create_buffer(info.size, conv::map_buffer_usage(info.usage))
+            .expect("Error on creating buffer");
+        *pBuffer = Handle::new(buffer);
+    };
     VkResult::VK_SUCCESS
 }
 #[inline]
@@ -1495,12 +1496,10 @@ pub extern "C" fn gfxDestroyBuffer(
     buffer: VkBuffer,
     _pAllocator: *const VkAllocationCallbacks,
 ) {
-    match buffer.unbox() {
-        Some(Buffer::Buffer(buffer)) => gpu.device.destroy_buffer(buffer),
-        Some(Buffer::Unbound(_)) => {
-            warn!("Trying to destroy a non-bound buffer, ignoring");
+    if let Some(buffer) = buffer.unbox() {
+        unsafe {
+            gpu.device.destroy_buffer(buffer);
         }
-        None => {}
     }
 }
 #[inline]
@@ -1517,15 +1516,13 @@ pub extern "C" fn gfxCreateBufferView(
         Some(info.offset + info.range)
     };
 
-    let view_result = gpu.device
-        .create_buffer_view(
-            match *info.buffer {
-                Buffer::Buffer(ref buffer) => buffer,
-                Buffer::Unbound(_) => unimplemented!(),
-            },
+    let view_result = unsafe {
+        gpu.device.create_buffer_view(
+            &info.buffer,
             conv::map_format(info.format),
             (Some(info.offset), end),
-        );
+        )
+    };
 
     match view_result {
         Ok(view) => {
@@ -1547,7 +1544,9 @@ pub extern "C" fn gfxDestroyBufferView(
     _pAllocator: *const VkAllocationCallbacks,
 ) {
     if let Some(v) = view.unbox() {
-        gpu.device.destroy_buffer_view(v);
+        unsafe {
+            gpu.device.destroy_buffer_view(v);
+        }
     }
 }
 #[inline]
@@ -1563,30 +1562,32 @@ pub extern "C" fn gfxCreateImage(
         warn!("unexpected initial layout: {:?}", info.initialLayout);
     }
 
-    let image = gpu.device
-        .create_image(
-            conv::map_image_kind(
-                info.imageType,
-                info.extent,
-                info.arrayLayers as _,
-                info.samples,
-            ),
-            info.mipLevels as _,
-            conv::map_format(info.format)
-                .expect(&format!("Unsupported image format: {:?}", info.format)),
-            conv::map_tiling(info.tiling),
-            conv::map_image_usage(info.usage),
-            conv::map_image_create_flags(info.flags),
-        )
-        .expect("Error on creating image");
-
+    let kind = conv::map_image_kind(
+        info.imageType,
+        info.extent,
+        info.arrayLayers as _,
+        info.samples,
+    );
     unsafe {
-        *pImage = Handle::new(Image::Unbound {
+        let image = gpu.device
+            .create_image(
+                kind,
+                info.mipLevels as _,
+                conv::map_format(info.format)
+                    .expect(&format!("Unsupported image format: {:?}", info.format)),
+                conv::map_tiling(info.tiling),
+                conv::map_image_usage(info.usage),
+                conv::map_image_create_flags(info.flags),
+            )
+            .expect("Error on creating image");
+
+        *pImage = Handle::new(Image {
             raw: image,
             mip_levels: info.mipLevels,
             array_layers: info.arrayLayers,
         });
     }
+
     VkResult::VK_SUCCESS
 }
 #[inline]
@@ -1595,12 +1596,10 @@ pub extern "C" fn gfxDestroyImage(
     image: VkImage,
     _pAllocator: *const VkAllocationCallbacks,
 ) {
-    match image.unbox() {
-        Some(Image::Image { raw, .. }) => gpu.device.destroy_image(raw),
-        Some(Image::Unbound { .. }) => {
-            warn!("Trying to destroy a non-bound image, ignoring");
+    if let Some(image) = image.unbox() {
+        unsafe {
+            gpu.device.destroy_image(image.raw);
         }
-        None => {}
     }
 }
 #[inline]
@@ -1610,10 +1609,13 @@ pub extern "C" fn gfxGetImageSubresourceLayout(
     pSubresource: *const VkImageSubresource,
     pLayout: *mut VkSubresourceLayout,
 ) {
-    let footprint = gpu.device.get_image_subresource_footprint(
-        image.expect("Bound image expected!"),
-        image.map_subresource(unsafe { *pSubresource} ),
-    );
+    let footprint = unsafe {
+        gpu.device.get_image_subresource_footprint(
+            &image.raw,
+            image.map_subresource(*pSubresource),
+        )
+    };
+
     let sub_layout = VkSubresourceLayout {
         offset: footprint.slice.start,
         size: footprint.slice.end - footprint.slice.start,
@@ -1621,6 +1623,7 @@ pub extern "C" fn gfxGetImageSubresourceLayout(
         depthPitch: footprint.depth_pitch,
         arrayPitch: footprint.array_pitch,
     };
+
     unsafe {
         *pLayout = sub_layout;
     }
@@ -1636,16 +1639,15 @@ pub extern "C" fn gfxCreateImageView(
     assert!(info.subresourceRange.levelCount != VK_REMAINING_MIP_LEVELS as _); // TODO
     assert!(info.subresourceRange.layerCount != VK_REMAINING_ARRAY_LAYERS as _); // TODO
 
-    // Non-sparse images must be bound prior.
-    let image = info.image.expect("Can't create view for unbound image");
-
-    let view = gpu.device.create_image_view(
-        image,
-        conv::map_view_kind(info.viewType),
-        conv::map_format(info.format).unwrap(),
-        conv::map_swizzle(info.components),
-        info.image.map_subresource_range(info.subresourceRange),
-    );
+    let view = unsafe {
+        gpu.device.create_image_view(
+            &info.image.raw,
+            conv::map_view_kind(info.viewType),
+            conv::map_format(info.format).unwrap(),
+            conv::map_swizzle(info.components),
+            info.image.map_subresource_range(info.subresourceRange),
+        )
+    };
 
     match view {
         Ok(view) => {
@@ -1662,7 +1664,9 @@ pub extern "C" fn gfxDestroyImageView(
     _pAllocator: *const VkAllocationCallbacks,
 ) {
     if let Some(view) = imageView.unbox() {
-        gpu.device.destroy_image_view(view);
+        unsafe {
+            gpu.device.destroy_image_view(view);
+        }
     }
 }
 #[inline]
@@ -1672,17 +1676,12 @@ pub extern "C" fn gfxCreateShaderModule(
     _pAllocator: *const VkAllocationCallbacks,
     pShaderModule: *mut VkShaderModule,
 ) -> VkResult {
-    let info = unsafe { &*pCreateInfo };
-    let code = unsafe {
-        slice::from_raw_parts(info.pCode as *const u8, info.codeSize as usize)
-    };
-
-    let shader_module = gpu
-        .device
-        .create_shader_module(code)
-        .expect("Error creating shader module"); // TODO
-
     unsafe {
+        let info = &*pCreateInfo;
+        let code = slice::from_raw_parts(info.pCode as *const u8, info.codeSize as usize);
+        let shader_module = gpu.device
+            .create_shader_module(code)
+            .expect("Error creating shader module"); // TODO
         *pShaderModule = Handle::new(shader_module);
     }
     VkResult::VK_SUCCESS
@@ -1694,7 +1693,9 @@ pub extern "C" fn gfxDestroyShaderModule(
     _pAllocator: *const VkAllocationCallbacks,
 ) {
     if let Some(module) = shaderModule.unbox() {
-        gpu.device.destroy_shader_module(module);
+        unsafe {
+            gpu.device.destroy_shader_module(module);
+        }
     }
 }
 #[inline]
@@ -1719,7 +1720,9 @@ pub extern "C" fn gfxDestroyPipelineCache(
     _pAllocator: *const VkAllocationCallbacks,
 ) {
     if let Some(cache) = pipelineCache.unbox() {
-        gpu.device.destroy_pipeline_cache(cache);
+        unsafe {
+            gpu.device.destroy_pipeline_cache(cache);
+        }
     }
 }
 #[inline]
@@ -1740,10 +1743,10 @@ pub extern "C" fn gfxMergePipelineCaches(
     srcCacheCount: u32,
     pSrcCaches: *const VkPipelineCache,
 ) -> VkResult {
-    let caches = unsafe {
-        slice::from_raw_parts(pSrcCaches, srcCacheCount as usize)
-    };
-    match gpu.device.merge_pipeline_caches(&*dstCache, caches.iter().map(|h| &**h)) {
+    match unsafe {
+        let caches = slice::from_raw_parts(pSrcCaches, srcCacheCount as usize);
+        gpu.device.merge_pipeline_caches(&*dstCache, caches.iter().map(|h| &**h))
+    } {
         Ok(()) => VkResult::VK_SUCCESS,
         Err(oom) => map_oom(oom),
     }
@@ -2168,7 +2171,9 @@ pub extern "C" fn gfxCreateGraphicsPipelines(
         }
     });
 
-    let pipelines = gpu.device.create_graphics_pipelines(descs, pipelineCache.as_ref());
+    let pipelines = unsafe {
+        gpu.device.create_graphics_pipelines(descs, pipelineCache.as_ref())
+    };
     let out_pipelines = unsafe {
         slice::from_raw_parts_mut(pPipelines, infos.len())
     };
@@ -2287,7 +2292,9 @@ pub extern "C" fn gfxCreateComputePipelines(
             }
         });
 
-    let pipelines = gpu.device.create_compute_pipelines(descs, pipelineCache.as_ref());
+    let pipelines = unsafe {
+        gpu.device.create_compute_pipelines(descs, pipelineCache.as_ref())
+    };
     let out_pipelines = unsafe {
         slice::from_raw_parts_mut(pPipelines, infos.len())
     };
@@ -2316,8 +2323,12 @@ pub extern "C" fn gfxDestroyPipeline(
     _pAllocator: *const VkAllocationCallbacks,
 ) {
     match pipeline.unbox() {
-        Some(Pipeline::Graphics(pipeline)) => gpu.device.destroy_graphics_pipeline(pipeline),
-        Some(Pipeline::Compute(pipeline)) => gpu.device.destroy_compute_pipeline(pipeline),
+        Some(Pipeline::Graphics(pipeline)) => unsafe {
+            gpu.device.destroy_graphics_pipeline(pipeline)
+        }
+        Some(Pipeline::Compute(pipeline)) => unsafe {
+            gpu.device.destroy_compute_pipeline(pipeline)
+        }
         None => {}
     }
 }
@@ -2350,7 +2361,9 @@ pub extern "C" fn gfxCreatePipelineLayout(
             (stages, start .. start+size)
         });
 
-    let pipeline_layout = match gpu.device.create_pipeline_layout(layouts, ranges) {
+    let pipeline_layout = match unsafe {
+        gpu.device.create_pipeline_layout(layouts, ranges)
+    } {
         Ok(pipeline) => pipeline,
         Err(oom) => return map_oom(oom),
     };
@@ -2365,7 +2378,9 @@ pub extern "C" fn gfxDestroyPipelineLayout(
     _pAllocator: *const VkAllocationCallbacks,
 ) {
     if let Some(layout) = pipelineLayout.unbox() {
-        gpu.device.destroy_pipeline_layout(layout);
+        unsafe {
+            gpu.device.destroy_pipeline_layout(layout);
+        }
     }
 }
 #[inline]
@@ -2399,7 +2414,9 @@ pub extern "C" fn gfxCreateSampler(
             hal::image::Anisotropic::Off
         },
     };
-    let sampler = match gpu.device.create_sampler(gfx_info) {
+    let sampler = match unsafe {
+        gpu.device.create_sampler(gfx_info)
+    } {
         Ok(s) => s,
         Err(alloc) => return map_alloc_error(alloc),
     };
@@ -2413,7 +2430,9 @@ pub extern "C" fn gfxDestroySampler(
     _pAllocator: *const VkAllocationCallbacks,
 ) {
     if let Some(sam) = sampler.unbox() {
-        gpu.device.destroy_sampler(sam);
+        unsafe {
+            gpu.device.destroy_sampler(sam);
+        }
     }
 }
 #[inline]
@@ -2451,7 +2470,9 @@ pub extern "C" fn gfxCreateDescriptorSetLayout(
             immutable_samplers: !binding.pImmutableSamplers.is_null(),
         });
 
-    let set_layout = match gpu.device.create_descriptor_set_layout(bindings, sampler_iter) {
+    let set_layout = match unsafe {
+        gpu.device.create_descriptor_set_layout(bindings, sampler_iter)
+    } {
         Ok(sl) => sl,
         Err(oom) => return map_oom(oom),
     };
@@ -2466,7 +2487,9 @@ pub extern "C" fn gfxDestroyDescriptorSetLayout(
     _pAllocator: *const VkAllocationCallbacks,
 ) {
     if let Some(layout) = descriptorSetLayout.unbox() {
-        gpu.device.destroy_descriptor_set_layout(layout);
+        unsafe {
+            gpu.device.destroy_descriptor_set_layout(layout);
+        }
     }
 }
 #[inline]
@@ -2493,7 +2516,9 @@ pub extern "C" fn gfxCreateDescriptorPool(
         });
 
     let pool = super::DescriptorPool {
-        raw: match gpu.device.create_descriptor_pool(max_sets, ranges) {
+        raw: match unsafe {
+            gpu.device.create_descriptor_pool(max_sets, ranges)
+        } {
             Ok(pool) => pool,
             Err(oom) => return map_oom(oom),
         },
@@ -2515,7 +2540,9 @@ pub extern "C" fn gfxDestroyDescriptorPool(
     _pAllocator: *const VkAllocationCallbacks,
 ) {
     if let Some(pool) = descriptorPool.unbox() {
-        gpu.device.destroy_descriptor_pool(pool.raw);
+        unsafe {
+            gpu.device.destroy_descriptor_pool(pool.raw);
+        }
         if let Some(sets) = pool.set_handles {
             for set in sets {
                 let _ = set.unbox();
@@ -2529,7 +2556,9 @@ pub extern "C" fn gfxResetDescriptorPool(
     mut descriptorPool: VkDescriptorPool,
     _flags: VkDescriptorPoolResetFlags,
 ) -> VkResult {
-    descriptorPool.raw.reset();
+    unsafe {
+        descriptorPool.raw.reset();
+    }
     if let Some(ref mut sets) = descriptorPool.set_handles {
         for set in sets.drain(..) {
             let _ = set.unbox();
@@ -2556,7 +2585,9 @@ pub extern "C" fn gfxAllocateDescriptorSets(
         .iter()
         .map(|layout| &**layout);
 
-    match raw.allocate_sets(layouts, temp_sets) {
+    match unsafe {
+        raw.allocate_sets(layouts, temp_sets)
+    } {
         Ok(()) => {
             assert_eq!(temp_sets.len(), info.descriptorSetCount as usize);
             for (set, raw_set) in out_sets.iter_mut().zip(temp_sets.drain(..)) {
@@ -2595,11 +2626,13 @@ pub extern "C" fn gfxFreeDescriptorSets(
     };
     assert!(descriptorPool.set_handles.is_none());
 
-    descriptorPool.raw.free_sets(
-        descriptor_sets
-            .into_iter()
-            .filter_map(|set| set.unbox())
-    );
+    let sets = descriptor_sets
+        .into_iter()
+        .filter_map(|set| set.unbox());
+
+    unsafe {
+        descriptorPool.raw.free_sets(sets);
+    }
 
     VkResult::VK_SUCCESS
 }
@@ -2651,7 +2684,7 @@ impl<'a> Iterator for DescriptorIter<'a> {
                     };
                     pso::Descriptor::Buffer(
                         // Non-sparse buffer need to be bound to device memory.
-                        buffer.buffer.expect("Buffer needs to be bound"),
+                        &*buffer.buffer,
                         Some(buffer.offset) .. end,
                     )
                 })
@@ -2717,8 +2750,10 @@ pub extern "C" fn gfxUpdateDescriptorSets(
             }
         });
 
-    gpu.device.write_descriptor_sets(writes);
-    gpu.device.copy_descriptor_sets(copies);
+    unsafe {
+        gpu.device.write_descriptor_sets(writes);
+        gpu.device.copy_descriptor_sets(copies);
+    }
 }
 #[inline]
 pub extern "C" fn gfxCreateFramebuffer(
@@ -2742,12 +2777,10 @@ pub extern "C" fn gfxCreateFramebuffer(
         depth: info.layers,
     };
 
-    let framebuffer = gpu
-        .device
-        .create_framebuffer(&*info.renderPass, attachments, extent)
-        .unwrap();
-
     unsafe {
+        let framebuffer = gpu.device
+            .create_framebuffer(&*info.renderPass, attachments, extent)
+            .unwrap();
         *pFramebuffer = Handle::new(framebuffer);
     }
 
@@ -2760,7 +2793,9 @@ pub extern "C" fn gfxDestroyFramebuffer(
     _pAllocator: *const VkAllocationCallbacks,
 ) {
     if let Some(fbo) = framebuffer.unbox() {
-        gpu.device.destroy_framebuffer(fbo);
+        unsafe {
+            gpu.device.destroy_framebuffer(fbo);
+        }
     }
 }
 #[inline]
@@ -2911,7 +2946,9 @@ pub extern "C" fn gfxCreateRenderPass(
             }
         });
 
-    let render_pass = match gpu.device.create_render_pass(attachments, subpasses, dependencies) {
+    let render_pass = match unsafe {
+        gpu.device.create_render_pass(attachments, subpasses, dependencies)
+    } {
         Ok(pass) => pass,
         Err(oom) => return map_oom(oom),
     };
@@ -2929,7 +2966,9 @@ pub extern "C" fn gfxDestroyRenderPass(
     _pAllocator: *const VkAllocationCallbacks,
 ) {
     if let Some(rp) = renderPass.unbox() {
-        gpu.device.destroy_render_pass(rp);
+        unsafe {
+            gpu.device.destroy_render_pass(rp);
+        }
     }
 }
 #[inline]
@@ -2966,7 +3005,9 @@ pub extern "C" fn gfxCreateCommandPool(
     }
 
     let pool = CommandPool {
-        pool: match gpu.device.create_command_pool(family, flags) {
+        pool: match unsafe {
+            gpu.device.create_command_pool(family, flags)
+        } {
             Ok(pool) => pool,
             Err(oom) => return map_oom(oom),
         },
@@ -2986,7 +3027,9 @@ pub extern "C" fn gfxDestroyCommandPool(
         for cmd_buf in cp.buffers {
             let _ = cmd_buf.unbox();
         }
-        gpu.device.destroy_command_pool(cp.pool);
+        unsafe {
+            gpu.device.destroy_command_pool(cp.pool);
+        }
     }
 }
 
@@ -2996,7 +3039,9 @@ pub extern "C" fn gfxResetCommandPool(
     mut commandPool: VkCommandPool,
     _flags: VkCommandPoolResetFlags,
 ) -> VkResult {
-    commandPool.pool.reset();
+    unsafe {
+        commandPool.pool.reset();
+    }
     VkResult::VK_SUCCESS
 }
 
@@ -3014,7 +3059,7 @@ pub extern "C" fn gfxAllocateCommandBuffers(
     };
 
     let count = info.commandBufferCount as usize;
-    let cmd_bufs = info.commandPool.pool.allocate(count, level);
+    let cmd_bufs = info.commandPool.pool.allocate_vec(count, level);
 
     let output = unsafe { slice::from_raw_parts_mut(pCommandBuffers, count) };
     for (out, cmd_buf) in output.iter_mut().zip(cmd_bufs) {
@@ -3037,8 +3082,10 @@ pub extern "C" fn gfxFreeCommandBuffers(
     };
     commandPool.buffers.retain(|buf| !slice.contains(buf));
 
-    let buffers = slice.iter().filter_map(|buffer| buffer.unbox()).collect();
-    unsafe { commandPool.pool.free(buffers) };
+    let buffers = slice.iter().filter_map(|buffer| buffer.unbox());
+    unsafe {
+        commandPool.pool.free(buffers);
+    }
 }
 
 #[inline]
@@ -3060,14 +3107,16 @@ pub extern "C" fn gfxBeginCommandBuffer(
         },
         None => com::CommandBufferInheritanceInfo::default(),
     };
-    commandBuffer.begin(conv::map_cmd_buffer_usage(info.flags), inheritance);
-
+    unsafe {
+        commandBuffer.begin(conv::map_cmd_buffer_usage(info.flags), inheritance);
+    }
     VkResult::VK_SUCCESS
 }
 #[inline]
 pub extern "C" fn gfxEndCommandBuffer(mut commandBuffer: VkCommandBuffer) -> VkResult {
-    commandBuffer.finish();
-
+    unsafe {
+        commandBuffer.finish();
+    }
     VkResult::VK_SUCCESS
 }
 #[inline]
@@ -3076,7 +3125,9 @@ pub extern "C" fn gfxResetCommandBuffer(
     flags: VkCommandBufferResetFlags,
 ) -> VkResult {
     let release_resources = flags & VkCommandBufferResetFlagBits::VK_COMMAND_BUFFER_RESET_RELEASE_RESOURCES_BIT as u32 != 0;
-    commandBuffer.reset(release_resources);
+    unsafe {
+        commandBuffer.reset(release_resources);
+    }
     VkResult::VK_SUCCESS
 }
 #[inline]
@@ -3086,8 +3137,12 @@ pub extern "C" fn gfxCmdBindPipeline(
     pipeline: VkPipeline,
 ) {
     match *pipeline {
-        Pipeline::Graphics(ref pipeline) => commandBuffer.bind_graphics_pipeline(pipeline),
-        Pipeline::Compute(ref pipeline) => commandBuffer.bind_compute_pipeline(pipeline),
+        Pipeline::Graphics(ref pipeline) => unsafe {
+            commandBuffer.bind_graphics_pipeline(pipeline)
+        }
+        Pipeline::Compute(ref pipeline) => unsafe {
+            commandBuffer.bind_compute_pipeline(pipeline)
+        }
     }
 }
 #[inline]
@@ -3097,13 +3152,12 @@ pub extern "C" fn gfxCmdSetViewport(
     viewportCount: u32,
     pViewports: *const VkViewport,
 ) {
-    let viewports = unsafe {
-        slice::from_raw_parts(pViewports, viewportCount as _)
+    unsafe {
+        let viewports = slice::from_raw_parts(pViewports, viewportCount as _)
             .into_iter()
-            .map(conv::map_viewport)
-    };
-
-    commandBuffer.set_viewports(firstViewport, viewports);
+            .map(conv::map_viewport);
+        commandBuffer.set_viewports(firstViewport, viewports);
+    }
 }
 #[inline]
 pub extern "C" fn gfxCmdSetScissor(
@@ -3112,17 +3166,18 @@ pub extern "C" fn gfxCmdSetScissor(
     scissorCount: u32,
     pScissors: *const VkRect2D,
 ) {
-    let scissors = unsafe {
-        slice::from_raw_parts(pScissors, scissorCount as _)
+    unsafe {
+        let scissors = slice::from_raw_parts(pScissors, scissorCount as _)
             .into_iter()
-            .map(conv::map_rect)
-    };
-
-    commandBuffer.set_scissors(firstScissor, scissors);
+            .map(conv::map_rect);
+        commandBuffer.set_scissors(firstScissor, scissors);
+    }
 }
 #[inline]
 pub extern "C" fn gfxCmdSetLineWidth(mut commandBuffer: VkCommandBuffer, lineWidth: f32) {
-    commandBuffer.set_line_width(lineWidth);
+    unsafe {
+        commandBuffer.set_line_width(lineWidth);
+    }
 }
 #[inline]
 pub extern "C" fn gfxCmdSetDepthBias(
@@ -3131,19 +3186,23 @@ pub extern "C" fn gfxCmdSetDepthBias(
     depthBiasClamp: f32,
     depthBiasSlopeFactor: f32,
 ) {
-    commandBuffer.set_depth_bias(pso::DepthBias {
-        const_factor: depthBiasConstantFactor,
-        clamp: depthBiasClamp,
-        slope_factor: depthBiasSlopeFactor,
-    });
+    unsafe {
+        commandBuffer.set_depth_bias(pso::DepthBias {
+            const_factor: depthBiasConstantFactor,
+            clamp: depthBiasClamp,
+            slope_factor: depthBiasSlopeFactor,
+        });
+    }
 }
 #[inline]
 pub extern "C" fn gfxCmdSetBlendConstants(
     mut commandBuffer: VkCommandBuffer,
     blendConstants: *const f32,
 ) {
-    let value = unsafe { *(blendConstants as *const pso::ColorValue) };
-    commandBuffer.set_blend_constants(value);
+    unsafe {
+        let value = *(blendConstants as *const pso::ColorValue);
+        commandBuffer.set_blend_constants(value);
+    }
 }
 #[inline]
 pub extern "C" fn gfxCmdSetDepthBounds(
@@ -3151,7 +3210,9 @@ pub extern "C" fn gfxCmdSetDepthBounds(
     minDepthBounds: f32,
     maxDepthBounds: f32,
 ) {
-    commandBuffer.set_depth_bounds(minDepthBounds .. maxDepthBounds);
+    unsafe {
+        commandBuffer.set_depth_bounds(minDepthBounds .. maxDepthBounds);
+    }
 }
 #[inline]
 pub extern "C" fn gfxCmdSetStencilCompareMask(
@@ -3159,10 +3220,12 @@ pub extern "C" fn gfxCmdSetStencilCompareMask(
     faceMask: VkStencilFaceFlags,
     compareMask: u32,
 ) {
-    commandBuffer.set_stencil_read_mask(
-        conv::map_stencil_face(faceMask),
-        compareMask,
-    );
+    unsafe {
+        commandBuffer.set_stencil_read_mask(
+            conv::map_stencil_face(faceMask),
+            compareMask,
+        );
+    }
 }
 #[inline]
 pub extern "C" fn gfxCmdSetStencilWriteMask(
@@ -3170,10 +3233,12 @@ pub extern "C" fn gfxCmdSetStencilWriteMask(
     faceMask: VkStencilFaceFlags,
     writeMask: u32,
 ) {
-    commandBuffer.set_stencil_write_mask(
-        conv::map_stencil_face(faceMask),
-        writeMask,
-    );
+    unsafe {
+        commandBuffer.set_stencil_write_mask(
+            conv::map_stencil_face(faceMask),
+            writeMask,
+        );
+    }
 }
 #[inline]
 pub extern "C" fn gfxCmdSetStencilReference(
@@ -3181,10 +3246,12 @@ pub extern "C" fn gfxCmdSetStencilReference(
     faceMask: VkStencilFaceFlags,
     reference: u32,
 ) {
-    commandBuffer.set_stencil_reference(
-        conv::map_stencil_face(faceMask),
-        reference,
-    );
+    unsafe {
+        commandBuffer.set_stencil_reference(
+            conv::map_stencil_face(faceMask),
+            reference,
+        );
+    }
 }
 #[inline]
 pub extern "C" fn gfxCmdBindDescriptorSets(
@@ -3207,7 +3274,7 @@ pub extern "C" fn gfxCmdBindDescriptorSets(
     };
 
     match pipelineBindPoint {
-        VkPipelineBindPoint::VK_PIPELINE_BIND_POINT_GRAPHICS => {
+        VkPipelineBindPoint::VK_PIPELINE_BIND_POINT_GRAPHICS => unsafe {
             commandBuffer.bind_graphics_descriptor_sets(
                 &*layout,
                 firstSet as _,
@@ -3215,7 +3282,7 @@ pub extern "C" fn gfxCmdBindDescriptorSets(
                 offsets,
             );
         }
-        VkPipelineBindPoint::VK_PIPELINE_BIND_POINT_COMPUTE => {
+        VkPipelineBindPoint::VK_PIPELINE_BIND_POINT_COMPUTE => unsafe {
             commandBuffer.bind_compute_descriptor_sets(
                 &*layout,
                 firstSet as _,
@@ -3233,13 +3300,15 @@ pub extern "C" fn gfxCmdBindIndexBuffer(
     offset: VkDeviceSize,
     indexType: VkIndexType,
 ) {
-    commandBuffer.bind_index_buffer(
-        IndexBufferView {
-            buffer: buffer.expect("Bound index buffer expected."),
-            offset,
-            index_type: conv::map_index_type(indexType),
-        }
-    );
+    unsafe {
+        commandBuffer.bind_index_buffer(
+            IndexBufferView {
+                buffer: &*buffer,
+                offset,
+                index_type: conv::map_index_type(indexType),
+            }
+        );
+    }
 }
 
 #[inline]
@@ -3261,11 +3330,12 @@ pub extern "C" fn gfxCmdBindVertexBuffers(
         .into_iter()
         .zip(offsets)
         .map(|(buffer, offset)| {
-            let buffer = buffer.expect("Non-sparse buffers need to be bound to device memory.");
-            (buffer, *offset)
+            (*buffer, *offset)
         });
 
-    commandBuffer.bind_vertex_buffers(firstBinding, views);
+    unsafe {
+        commandBuffer.bind_vertex_buffers(firstBinding, views);
+    }
 }
 #[inline]
 pub extern "C" fn gfxCmdDraw(
@@ -3275,10 +3345,12 @@ pub extern "C" fn gfxCmdDraw(
     firstVertex: u32,
     firstInstance: u32,
 ) {
-    commandBuffer.draw(
-        firstVertex .. firstVertex + vertexCount,
-        firstInstance .. firstInstance + instanceCount,
-    )
+    unsafe {
+        commandBuffer.draw(
+            firstVertex .. firstVertex + vertexCount,
+            firstInstance .. firstInstance + instanceCount,
+        );
+    }
 }
 #[inline]
 pub extern "C" fn gfxCmdDrawIndexed(
@@ -3289,11 +3361,13 @@ pub extern "C" fn gfxCmdDrawIndexed(
     vertexOffset: i32,
     firstInstance: u32,
 ) {
-    commandBuffer.draw_indexed(
-        firstIndex .. firstIndex + indexCount,
-        vertexOffset,
-        firstInstance .. firstInstance + instanceCount,
-    )
+    unsafe {
+        commandBuffer.draw_indexed(
+            firstIndex .. firstIndex + indexCount,
+            vertexOffset,
+            firstInstance .. firstInstance + instanceCount,
+        );
+    }
 }
 #[inline]
 pub extern "C" fn gfxCmdDrawIndirect(
@@ -3303,12 +3377,14 @@ pub extern "C" fn gfxCmdDrawIndirect(
     drawCount: u32,
     stride: u32,
 ) {
-    commandBuffer.draw_indirect(
-        buffer.expect("Bound buffer expected!"),
-        offset,
-        drawCount,
-        stride,
-    )
+    unsafe {
+        commandBuffer.draw_indirect(
+            &*buffer,
+            offset,
+            drawCount,
+            stride,
+        );
+    }
 }
 #[inline]
 pub extern "C" fn gfxCmdDrawIndexedIndirect(
@@ -3318,12 +3394,14 @@ pub extern "C" fn gfxCmdDrawIndexedIndirect(
     drawCount: u32,
     stride: u32,
 ) {
-    commandBuffer.draw_indexed_indirect(
-        buffer.expect("Bound buffer expected!"),
-        offset,
-        drawCount,
-        stride,
-    )
+    unsafe {
+        commandBuffer.draw_indexed_indirect(
+            &*buffer,
+            offset,
+            drawCount,
+            stride,
+        );
+    }
 }
 #[inline]
 pub extern "C" fn gfxCmdDispatch(
@@ -3332,7 +3410,9 @@ pub extern "C" fn gfxCmdDispatch(
     groupCountY: u32,
     groupCountZ: u32,
 ) {
-    commandBuffer.dispatch([groupCountX, groupCountY, groupCountZ])
+    unsafe {
+        commandBuffer.dispatch([groupCountX, groupCountY, groupCountZ]);
+    }
 }
 #[inline]
 pub extern "C" fn gfxCmdDispatchIndirect(
@@ -3340,10 +3420,12 @@ pub extern "C" fn gfxCmdDispatchIndirect(
     buffer: VkBuffer,
     offset: VkDeviceSize,
 ) {
-    commandBuffer.dispatch_indirect(
-        buffer.expect("Bound buffer expected!"),
-        offset,
-    )
+    unsafe {
+        commandBuffer.dispatch_indirect(
+            &*buffer,
+            offset,
+        );
+    }
 }
 #[inline]
 pub extern "C" fn gfxCmdCopyBuffer(
@@ -3363,11 +3445,13 @@ pub extern "C" fn gfxCmdCopyBuffer(
             size: r.size,
         });
 
-    commandBuffer.copy_buffer(
-        srcBuffer.expect("Bound src buffer expected!"),
-        dstBuffer.expect("Bound dst buffer expected!"),
-        regions,
-    );
+    unsafe {
+        commandBuffer.copy_buffer(
+            &*srcBuffer,
+            &*dstBuffer,
+            regions,
+        );
+    }
 }
 #[inline]
 pub extern "C" fn gfxCmdCopyImage(
@@ -3391,13 +3475,15 @@ pub extern "C" fn gfxCmdCopyImage(
             extent: conv::map_extent(r.extent),
         });
 
-    commandBuffer.copy_image(
-        srcImage.expect("Bound src image expected!"),
-        conv::map_image_layout(srcImageLayout),
-        dstImage.expect("Bound dst image expected!"),
-        conv::map_image_layout(dstImageLayout),
-        regions,
-    );
+    unsafe {
+        commandBuffer.copy_image(
+            &srcImage.raw,
+            conv::map_image_layout(srcImageLayout),
+            &dstImage.raw,
+            conv::map_image_layout(dstImageLayout),
+            regions,
+        );
+    }
 }
 #[inline]
 pub extern "C" fn gfxCmdBlitImage(
@@ -3421,14 +3507,16 @@ pub extern "C" fn gfxCmdBlitImage(
             dst_bounds: conv::map_offset(r.dstOffsets[0]) .. conv::map_offset(r.dstOffsets[1]),
         });
 
-    commandBuffer.blit_image(
-        srcImage.expect("Bound src image expected!"),
-        conv::map_image_layout(srcImageLayout),
-        dstImage.expect("Bound dst image expected!"),
-        conv::map_image_layout(dstImageLayout),
-        conv::map_filter(filter),
-        regions,
-    );
+    unsafe {
+        commandBuffer.blit_image(
+            &srcImage.raw,
+            conv::map_image_layout(srcImageLayout),
+            &dstImage.raw,
+            conv::map_image_layout(dstImageLayout),
+            conv::map_filter(filter),
+            regions,
+        );
+    }
 }
 #[inline]
 pub extern "C" fn gfxCmdCopyBufferToImage(
@@ -3452,12 +3540,14 @@ pub extern "C" fn gfxCmdCopyBufferToImage(
             image_extent: conv::map_extent(r.imageExtent),
         });
 
-    commandBuffer.copy_buffer_to_image(
-        srcBuffer.expect("Bound buffer expected!"),
-        dstImage.expect("Bound image expected!"),
-        conv::map_image_layout(dstImageLayout),
-        regions,
-    );
+    unsafe {
+        commandBuffer.copy_buffer_to_image(
+            &*srcBuffer,
+            &dstImage.raw,
+            conv::map_image_layout(dstImageLayout),
+            regions,
+        );
+    }
 }
 #[inline]
 pub extern "C" fn gfxCmdCopyImageToBuffer(
@@ -3481,12 +3571,14 @@ pub extern "C" fn gfxCmdCopyImageToBuffer(
             image_extent: conv::map_extent(r.imageExtent),
         });
 
-    commandBuffer.copy_image_to_buffer(
-        srcImage.expect("Bound image expected!"),
-        conv::map_image_layout(srcImageLayout),
-        dstBuffer.expect("Bound buffer expected!"),
-        regions,
-    );
+    unsafe {
+        commandBuffer.copy_image_to_buffer(
+            &srcImage.raw,
+            conv::map_image_layout(srcImageLayout),
+            &*dstBuffer,
+            regions,
+        );
+    }
 }
 #[inline]
 pub extern "C" fn gfxCmdUpdateBuffer(
@@ -3496,13 +3588,13 @@ pub extern "C" fn gfxCmdUpdateBuffer(
     dataSize: VkDeviceSize,
     pData: *const ::std::os::raw::c_void,
 ) {
-    commandBuffer.update_buffer(
-        dstBuffer.expect("Bound buffer expected!"),
-        dstOffset,
-        unsafe {
-            slice::from_raw_parts(pData as _, dataSize as _)
-        },
-    );
+    unsafe {
+        commandBuffer.update_buffer(
+            &*dstBuffer,
+            dstOffset,
+            slice::from_raw_parts(pData as _, dataSize as _),
+        );
+    }
 }
 #[inline]
 pub extern "C" fn gfxCmdFillBuffer(
@@ -3517,11 +3609,13 @@ pub extern "C" fn gfxCmdFillBuffer(
     } else {
         (Some(dstOffset), Some(dstOffset + size))
     };
-    commandBuffer.fill_buffer(
-        dstBuffer.expect("Bound buffer expected!"),
-        range,
-        data,
-    );
+    unsafe {
+        commandBuffer.fill_buffer(
+            &*dstBuffer,
+            range,
+            data,
+        );
+    }
 }
 #[inline]
 pub extern "C" fn gfxCmdClearColorImage(
@@ -3533,17 +3627,20 @@ pub extern "C" fn gfxCmdClearColorImage(
     pRanges: *const VkImageSubresourceRange,
 ) {
     let subresource_ranges = unsafe {
-        slice::from_raw_parts(pRanges, rangeCount as _)
-    };
-    commandBuffer.clear_image(
-        image.expect("Bound image expected!"),
-        conv::map_image_layout(imageLayout),
-        unsafe { mem::transmute(*pColor) },
-        unsafe { mem::zeroed() },
-        subresource_ranges
-            .iter()
-            .map(|&range| image.map_subresource_range(range)),
-    );
+            slice::from_raw_parts(pRanges, rangeCount as _)
+        }
+        .iter()
+        .map(|&range| image.map_subresource_range(range));
+
+    unsafe {
+        commandBuffer.clear_image(
+            &image.raw,
+            conv::map_image_layout(imageLayout),
+            mem::transmute(*pColor),
+            mem::zeroed(),
+            subresource_ranges,
+        );
+    }
 }
 #[inline]
 pub extern "C" fn gfxCmdClearDepthStencilImage(
@@ -3555,17 +3652,20 @@ pub extern "C" fn gfxCmdClearDepthStencilImage(
     pRanges: *const VkImageSubresourceRange,
 ) {
     let subresource_ranges = unsafe {
-        slice::from_raw_parts(pRanges, rangeCount as _)
-    };
-    commandBuffer.clear_image(
-        image.expect("Bound image expected!"),
-        conv::map_image_layout(imageLayout),
-        unsafe { mem::zeroed() },
-        unsafe { mem::transmute(*pDepthStencil) },
-        subresource_ranges
-            .iter()
-            .map(|&range| image.map_subresource_range(range)),
-    );
+            slice::from_raw_parts(pRanges, rangeCount as _)
+        }
+        .iter()
+        .map(|&range| image.map_subresource_range(range));
+
+    unsafe {
+        commandBuffer.clear_image(
+            &image.raw,
+            conv::map_image_layout(imageLayout),
+            mem::zeroed(),
+            mem::transmute(*pDepthStencil),
+            subresource_ranges
+        );
+    }
 }
 #[inline]
 pub extern "C" fn gfxCmdClearAttachments(
@@ -3576,13 +3676,10 @@ pub extern "C" fn gfxCmdClearAttachments(
     pRects: *const VkClearRect,
 ) {
     let attachments = unsafe {
-        slice::from_raw_parts(pAttachments, attachmentCount as _)
-    };
-    let rects = unsafe {
-        slice::from_raw_parts(pRects, rectCount as _)
-    };
-    commandBuffer.clear_attachments(
-        attachments.iter().map(|at| {
+            slice::from_raw_parts(pAttachments, attachmentCount as _)
+        }
+        .iter()
+        .map(|at| {
             use VkImageAspectFlagBits::*;
             if at.aspectMask & VK_IMAGE_ASPECT_COLOR_BIT as u32 != 0 {
                 com::AttachmentClear::Color {
@@ -3599,9 +3696,20 @@ pub extern "C" fn gfxCmdClearAttachments(
                     } else { None },
                 }
             }
-        }),
-        rects.iter().map(conv::map_clear_rect),
-    );
+        });
+
+    let rects = unsafe {
+            slice::from_raw_parts(pRects, rectCount as _)
+        }
+        .iter()
+        .map(conv::map_clear_rect);
+
+    unsafe {
+        commandBuffer.clear_attachments(
+            attachments,
+            rects
+        );
+    }
 }
 #[inline]
 pub extern "C" fn gfxCmdResolveImage(
@@ -3614,22 +3722,27 @@ pub extern "C" fn gfxCmdResolveImage(
     pRegions: *const VkImageResolve,
 ) {
     let regions = unsafe {
-        slice::from_raw_parts(pRegions, regionCount as _)
-    }.iter().cloned().map(|resolve| com::ImageResolve {
-        src_subresource: srcImage.map_subresource_layers(resolve.srcSubresource),
-        src_offset: conv::map_offset(resolve.srcOffset),
-        dst_subresource: srcImage.map_subresource_layers(resolve.dstSubresource),
-        dst_offset: conv::map_offset(resolve.dstOffset),
-        extent: conv::map_extent(resolve.extent),
-    });
+            slice::from_raw_parts(pRegions, regionCount as _)
+        }
+        .iter()
+        .cloned()
+        .map(|resolve| com::ImageResolve {
+            src_subresource: srcImage.map_subresource_layers(resolve.srcSubresource),
+            src_offset: conv::map_offset(resolve.srcOffset),
+            dst_subresource: srcImage.map_subresource_layers(resolve.dstSubresource),
+            dst_offset: conv::map_offset(resolve.dstOffset),
+            extent: conv::map_extent(resolve.extent),
+        });
 
-    commandBuffer.resolve_image(
-        srcImage.expect("Bound image expected!"),
-        conv::map_image_layout(srcImageLayout),
-        dstImage.expect("Bound image expected!"),
-        conv::map_image_layout(dstImageLayout),
-        regions,
-    );
+    unsafe {
+        commandBuffer.resolve_image(
+            &srcImage.raw,
+            conv::map_image_layout(srcImageLayout),
+            &dstImage.raw,
+            conv::map_image_layout(dstImageLayout),
+            regions,
+        );
+    }
 }
 #[inline]
 pub extern "C" fn gfxCmdSetEvent(
@@ -3702,7 +3815,9 @@ pub extern "C" fn gfxCmdPipelineBarrier(
         .iter()
         .map(|b| memory::Barrier::Buffer {
             states: conv::map_buffer_access(b.srcAccessMask) .. conv::map_buffer_access(b.dstAccessMask),
-            target: b.buffer.expect("Bound buffer is needed here!"),
+            target: &*b.buffer,
+            range: Some(b.offset) .. if b.size as i32 == VK_WHOLE_SIZE { None } else { Some(b.offset + b.size) },
+            families: None,
         });
 
     let image_barriers = unsafe {
@@ -3713,15 +3828,18 @@ pub extern "C" fn gfxCmdPipelineBarrier(
             states:
                 (conv::map_image_access(b.srcAccessMask), conv::map_image_layout(b.oldLayout)) ..
                 (conv::map_image_access(b.dstAccessMask), conv::map_image_layout(b.newLayout)),
-            target: b.image.expect("Bound image is needed here!"),
+            target: &b.image.raw,
             range: b.image.map_subresource_range(b.subresourceRange),
+            families: None,
         });
 
-    commandBuffer.pipeline_barrier(
-        conv::map_pipeline_stage_flags(srcStageMask) .. conv::map_pipeline_stage_flags(dstStageMask),
-        memory::Dependencies::from_bits(dependencyFlags as _).unwrap_or(memory::Dependencies::empty()),
-        global_barriers.chain(buffer_barriers).chain(image_barriers),
-    );
+    unsafe {
+        commandBuffer.pipeline_barrier(
+            conv::map_pipeline_stage_flags(srcStageMask) .. conv::map_pipeline_stage_flags(dstStageMask),
+            memory::Dependencies::from_bits(dependencyFlags as _).unwrap_or(memory::Dependencies::empty()),
+            global_barriers.chain(buffer_barriers).chain(image_barriers),
+        );
+    }
 }
 #[inline]
 pub extern "C" fn gfxCmdBeginQuery(
@@ -3734,7 +3852,9 @@ pub extern "C" fn gfxCmdBeginQuery(
         pool: &*queryPool,
         id: query,
     };
-    commandBuffer.begin_query(query, conv::map_query_control(flags));
+    unsafe {
+        commandBuffer.begin_query(query, conv::map_query_control(flags));
+    }
 }
 #[inline]
 pub extern "C" fn gfxCmdEndQuery(
@@ -3746,7 +3866,9 @@ pub extern "C" fn gfxCmdEndQuery(
         pool: &*queryPool,
         id: query,
     };
-    commandBuffer.end_query(query);
+    unsafe {
+        commandBuffer.end_query(query);
+    }
 }
 #[inline]
 pub extern "C" fn gfxCmdResetQueryPool(
@@ -3755,7 +3877,9 @@ pub extern "C" fn gfxCmdResetQueryPool(
     firstQuery: u32,
     queryCount: u32,
 ) {
-    commandBuffer.reset_query_pool(&*queryPool, firstQuery .. firstQuery + queryCount);
+    unsafe {
+        commandBuffer.reset_query_pool(&*queryPool, firstQuery .. firstQuery + queryCount);
+    }
 }
 #[inline]
 pub extern "C" fn gfxCmdWriteTimestamp(
@@ -3768,7 +3892,9 @@ pub extern "C" fn gfxCmdWriteTimestamp(
         pool: &*queryPool,
         id: query,
     };
-    commandBuffer.write_timestamp(conv::map_pipeline_stage_flags(pipelineStage as u32), query);
+    unsafe {
+        commandBuffer.write_timestamp(conv::map_pipeline_stage_flags(pipelineStage as u32), query);
+    }
 }
 #[inline]
 pub extern "C" fn gfxCmdCopyQueryPoolResults(
@@ -3781,14 +3907,16 @@ pub extern "C" fn gfxCmdCopyQueryPoolResults(
     stride: VkDeviceSize,
     flags: VkQueryResultFlags,
 ) {
-    commandBuffer.copy_query_pool_results(
-        &*queryPool,
-        firstQuery .. firstQuery + queryCount,
-        dstBuffer.expect("Invalid destination buffer!"),
-        dstOffset,
-        stride,
-        conv::map_query_result(flags),
-    );
+    unsafe {
+        commandBuffer.copy_query_pool_results(
+            &*queryPool,
+            firstQuery .. firstQuery + queryCount,
+            &*dstBuffer,
+            dstOffset,
+            stride,
+            conv::map_query_result(flags),
+        );
+    }
 }
 #[inline]
 pub extern "C" fn gfxCmdPushConstants(
@@ -3800,25 +3928,24 @@ pub extern "C" fn gfxCmdPushConstants(
     pValues: *const ::std::os::raw::c_void,
 ) {
     assert_eq!(size % 4, 0);
+    unsafe {
+        let values = slice::from_raw_parts(pValues as *const u32, size as usize / 4);
 
-    let values = unsafe {
-        slice::from_raw_parts(pValues as *const u32, size as usize / 4)
-    };
-
-    if stageFlags & VkShaderStageFlagBits::VK_SHADER_STAGE_COMPUTE_BIT as u32 != 0 {
-        commandBuffer.push_compute_constants(
-            &*layout,
-            offset,
-            values,
-        );
-    }
-    if stageFlags & VkShaderStageFlagBits::VK_SHADER_STAGE_ALL_GRAPHICS as u32 != 0 {
-        commandBuffer.push_graphics_constants(
-            &*layout,
-            conv::map_stage_flags(stageFlags),
-            offset,
-            values,
-        );
+        if stageFlags & VkShaderStageFlagBits::VK_SHADER_STAGE_COMPUTE_BIT as u32 != 0 {
+            commandBuffer.push_compute_constants(
+                &*layout,
+                offset,
+                values,
+            );
+        }
+        if stageFlags & VkShaderStageFlagBits::VK_SHADER_STAGE_ALL_GRAPHICS as u32 != 0 {
+            commandBuffer.push_graphics_constants(
+                &*layout,
+                conv::map_stage_flags(stageFlags),
+                offset,
+                values,
+            );
+        }
     }
 }
 #[inline]
@@ -3845,26 +3972,32 @@ pub extern "C" fn gfxCmdBeginRenderPass(
     };
     let contents = conv::map_subpass_contents(contents);
 
-    commandBuffer.begin_render_pass(
-        &*info.renderPass,
-        &*info.framebuffer,
-        render_area,
-        clear_values,
-        contents,
-    );
+    unsafe {
+        commandBuffer.begin_render_pass(
+            &*info.renderPass,
+            &*info.framebuffer,
+            render_area,
+            clear_values,
+            contents,
+        );
+    }
 }
 #[inline]
 pub extern "C" fn gfxCmdNextSubpass(
     mut commandBuffer: VkCommandBuffer,
     contents: VkSubpassContents,
 ) {
-    commandBuffer.next_subpass(conv::map_subpass_contents(contents));
+    unsafe {
+        commandBuffer.next_subpass(conv::map_subpass_contents(contents));
+    }
 }
 #[inline]
 pub extern "C" fn gfxCmdEndRenderPass(
     mut commandBuffer: VkCommandBuffer,
 ) {
-    commandBuffer.end_render_pass();
+    unsafe {
+        commandBuffer.end_render_pass();
+    }
 }
 #[inline]
 pub extern "C" fn gfxCmdExecuteCommands(
@@ -3872,10 +4005,11 @@ pub extern "C" fn gfxCmdExecuteCommands(
     commandBufferCount: u32,
     pCommandBuffers: *const VkCommandBuffer,
 ) {
-    let cmd_buffers = unsafe {
-        slice::from_raw_parts(pCommandBuffers, commandBufferCount as _)
-    };
-    commandBuffer.execute_commands(cmd_buffers.iter().map(|cb| *cb));
+    unsafe {
+        commandBuffer.execute_commands(
+            slice::from_raw_parts(pCommandBuffers, commandBufferCount as _),
+        );
+    }
 }
 
 #[inline]
@@ -3906,7 +4040,22 @@ pub extern "C" fn gfxGetPhysicalDeviceSurfaceCapabilitiesKHR(
     surface: VkSurfaceKHR,
     pSurfaceCapabilities: *mut VkSurfaceCapabilitiesKHR,
 ) -> VkResult {
-    let (caps, _, _) = surface.compatibility(&adapter.physical_device);
+    let (caps, _, _supported_transforms, supported_alphas) =
+        surface.compatibility(&adapter.physical_device);
+
+    let mut composite_alpha_mask: VkCompositeAlphaFlagsKHR = 0;
+    for ca in supported_alphas {
+        composite_alpha_mask |= match ca {
+            hal::window::CompositeAlpha::Opaque =>
+                VkCompositeAlphaFlagBitsKHR::VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR as u32,
+            hal::window::CompositeAlpha::PreMultiplied =>
+                VkCompositeAlphaFlagBitsKHR::VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR as u32,
+            hal::window::CompositeAlpha::PostMultiplied =>
+                VkCompositeAlphaFlagBitsKHR::VK_COMPOSITE_ALPHA_POST_MULTIPLIED_BIT_KHR as u32,
+            hal::window::CompositeAlpha::Inherit =>
+                VkCompositeAlphaFlagBitsKHR::VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR as u32,
+        };
+    }
 
     let output = VkSurfaceCapabilitiesKHR {
         minImageCount: caps.image_count.start,
@@ -3924,8 +4073,7 @@ pub extern "C" fn gfxGetPhysicalDeviceSurfaceCapabilitiesKHR(
         supportedTransforms: VkSurfaceTransformFlagBitsKHR::VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR
             as _,
         currentTransform: VkSurfaceTransformFlagBitsKHR::VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR,
-        supportedCompositeAlpha: VkCompositeAlphaFlagBitsKHR::VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR
-            as _,
+        supportedCompositeAlpha: composite_alpha_mask,
         supportedUsageFlags: conv::map_image_usage_from_hal(caps.usage),
     };
 
@@ -3973,7 +4121,7 @@ pub extern "C" fn gfxGetPhysicalDeviceSurfacePresentModesKHR(
     pPresentModeCount: *mut u32,
     pPresentModes: *mut VkPresentModeKHR,
 ) -> VkResult {
-    let (_, _, present_modes) = surface
+    let (_, _, present_modes, _) = surface
         .compatibility(&adapter.physical_device);
 
     let num_present_modes = present_modes.len();
@@ -4017,17 +4165,20 @@ pub extern "C" fn gfxCreateSwapchainKHR(
 
     let config = hal::SwapchainConfig {
         present_mode: conv::map_present_mode(info.presentMode),
+        composite_alpha: conv::map_composite_alpha(info.compositeAlpha),
         format: conv::map_format(info.imageFormat).unwrap(),
         extent: conv::map_extent2d(info.imageExtent),
         image_count: info.minImageCount,
         image_layers: 1,
         image_usage: conv::map_image_usage(info.imageUsage),
     };
-    let (mut swapchain, backbuffers) = match gpu.device.create_swapchain(
-        &mut info.surface.clone(),
-        config,
-        info.oldSwapchain.as_mut().and_then(|s| s.raw.take()), //Note: no unboxing!
-    ) {
+    let (mut swapchain, backbuffers) = match unsafe {
+        gpu.device.create_swapchain(
+            &mut info.surface.clone(),
+            config,
+            info.oldSwapchain.as_mut().and_then(|s| s.raw.take()), //Note: no unboxing!
+        )
+    } {
         Ok(pair) => pair,
         Err(hal::window::CreationError::OutOfMemory(oom)) => return map_oom(oom),
         Err(hal::window::CreationError::DeviceLost(hal::device::DeviceLost)) => return VkResult::VK_ERROR_DEVICE_LOST,
@@ -4053,8 +4204,8 @@ pub extern "C" fn gfxCreateSwapchainKHR(
     let images = match backbuffers {
         hal::Backbuffer::Images(images) => images
             .into_iter()
-            .map(|image| Handle::new(Image::Image {
-                raw: image,
+            .map(|raw| Handle::new(Image {
+                raw,
                 mip_levels: 1,
                 array_layers: 1,
             }))
@@ -4344,7 +4495,9 @@ pub extern "C" fn gfxAcquireNextImageKHR(
         None => return VkResult::VK_ERROR_OUT_OF_DATE_KHR,
     };
 
-    match raw.acquire_image(timeout, sync) {
+    match unsafe {
+        raw.acquire_image(timeout, sync)
+    } {
         Ok(frame) => {
             unsafe { *pImageIndex = frame; }
             VkResult::VK_SUCCESS
@@ -4378,7 +4531,9 @@ pub extern "C" fn gfxQueuePresentKHR(
             .map(|semaphore| &**semaphore)
     };
 
-    queue.present(swapchains, wait_semaphores).unwrap();
+    unsafe {
+        queue.present(swapchains, wait_semaphores).unwrap();
+    }
 
     VkResult::VK_SUCCESS
 }


### PR DESCRIPTION
The big update to hal-0.1 and beyond.
I'm not sure that trying to minimize the `unsafe` spots was the right decision... perhaps it's easier to just mark all of gfxXxx methods unsafe, but I'm too tired now to rewrite it again.