### PR TITLE
Add transfer bit to all queue families

### DIFF
--- a/libportability-gfx/src/impls.rs
+++ b/libportability-gfx/src/impls.rs
@@ -183,9 +183,12 @@ pub extern "C" fn gfxGetPhysicalDeviceQueueFamilyProperties(
                 hal::QueueType::General => {
                     VkQueueFlagBits::VK_QUEUE_GRAPHICS_BIT as u32
                         | VkQueueFlagBits::VK_QUEUE_COMPUTE_BIT as u32
+                        | VkQueueFlagBits::VK_QUEUE_TRANSFER_BIT as u32
                 }
-                hal::QueueType::Graphics => VkQueueFlagBits::VK_QUEUE_GRAPHICS_BIT as u32,
-                hal::QueueType::Compute => VkQueueFlagBits::VK_QUEUE_COMPUTE_BIT as u32,
+                hal::QueueType::Graphics => VkQueueFlagBits::VK_QUEUE_GRAPHICS_BIT as u32
+                    | VkQueueFlagBits::VK_QUEUE_TRANSFER_BIT as u32,
+                hal::QueueType::Compute => VkQueueFlagBits::VK_QUEUE_COMPUTE_BIT as u32
+                    | VkQueueFlagBits::VK_QUEUE_TRANSFER_BIT as u32,
                 hal::QueueType::Transfer => VkQueueFlagBits::VK_QUEUE_TRANSFER_BIT as u32,
             },
             queueCount: family.max_queues() as _,


### PR DESCRIPTION
Per the `gfx_hal::queue::QueueType` [docs](https://docs.rs/gfx-hal/0.2.0/gfx_hal/queue/enum.QueueType.html), all variants should include transfer operations. Notably, `General` now contains all three queue types.