### PR TITLE
fixes crash when enumerating on some systems

### DIFF
--- a/libportability-gfx/src/impls.rs
+++ b/libportability-gfx/src/impls.rs
@@ -164,7 +164,7 @@ pub extern "C" fn gfxEnumeratePhysicalDevices(
         (VkResult::VK_SUCCESS, num_adapters)
     };
 
-    output.copy_from_slice(&instance.adapters[..count]);
+    output[..count].copy_from_slice(&instance.adapters[..count]);
     unsafe { *pPhysicalDeviceCount = count as _ };
 
     code


### PR DESCRIPTION
Was crashing when calling `vulkaninfo`. I did some digging:

In gfxEnumeratePhysicalDevices, there is some logic for dealing with the cases where the slots allocated by the caller aren't enough to fit all the adapters the implementation has available. This logic has a flaw though, because it doesn't account for the cases where `num_output` is greater than the numbers of adapters gfx has to offer, and in that case the output is oversized wrt to the adapters we have to fit inside.

This matches both sides for calling copy_from_slice in that function. Not sure why this happens, I have a proper vulkan-ready device in this computer with a "proper" driver too, which may or may not explain it ? I'm not knowledgeable enough on how the loader and everything works to make a definitive statement. 

This made things work on my pc so ¯\\_(ツ)_/¯