### PR TITLE
Added vkGetPhysicalDeviceWin32PresentationSupportKHR

### DIFF
--- a/libportability-gfx/src/impls.rs
+++ b/libportability-gfx/src/impls.rs
@@ -521,6 +521,7 @@ pub extern "C" fn gfxGetInstanceProcAddr(
         vkGetPhysicalDeviceSurfaceCapabilitiesKHR, PFN_vkGetPhysicalDeviceSurfaceCapabilitiesKHR => gfxGetPhysicalDeviceSurfaceCapabilitiesKHR,
         vkGetPhysicalDeviceSurfaceFormatsKHR, PFN_vkGetPhysicalDeviceSurfaceFormatsKHR => gfxGetPhysicalDeviceSurfaceFormatsKHR,
         vkGetPhysicalDeviceSurfacePresentModesKHR, PFN_vkGetPhysicalDeviceSurfacePresentModesKHR => gfxGetPhysicalDeviceSurfacePresentModesKHR,
+        vkGetPhysicalDeviceWin32PresentationSupportKHR, PFN_vkGetPhysicalDeviceWin32PresentationSupportKHR => gfxGetPhysicalDeviceWin32PresentationSupportKHR,
 
         vkCreateWin32SurfaceKHR, PFN_vkCreateWin32SurfaceKHR => gfxCreateWin32SurfaceKHR,
         vkCreateMetalSurfaceEXT, PFN_vkCreateMetalSurfaceEXT => gfxCreateMetalSurfaceEXT,
@@ -4382,6 +4383,14 @@ pub extern "C" fn gfxGetPhysicalDeviceSurfacePresentModesKHR(
 
     unsafe { *pPresentModeCount = count as _ };
     code
+}
+
+#[inline]
+pub extern "C" fn gfxGetPhysicalDeviceWin32PresentationSupportKHR(
+    adapter: VkPhysicalDevice,
+    queueFamilyIndex: u32
+) -> VkBool32 {
+    VK_TRUE
 }
 
 #[inline]

--- a/libportability-gfx/src/lib.rs
+++ b/libportability-gfx/src/lib.rs
@@ -6938,6 +6938,10 @@ pub type PFN_vkCreateMacOSSurfaceMVK = ::std::option::Option<unsafe extern "C" f
     pSurface: *mut VkSurfaceKHR,
 ) -> VkResult>;
 
+pub type PFN_vkGetPhysicalDeviceWin32PresentationSupportKHR = ::std::option::Option<unsafe extern "C" fn(
+    physicalDevice: VkPhysicalDevice,
+    queueFamilyIndex: u32,
+) -> VkBool32>;
 
 #[repr(C)]
 #[derive(Debug, Copy)]

--- a/libportability-icd/src/lib.rs
+++ b/libportability-icd/src/lib.rs
@@ -55,5 +55,6 @@ pub extern "C" fn vk_icdGetPhysicalDeviceProcAddr(
         vkGetPhysicalDeviceSurfaceCapabilitiesKHR, PFN_vkGetPhysicalDeviceSurfaceCapabilitiesKHR => gfxGetPhysicalDeviceSurfaceCapabilitiesKHR,
         vkGetPhysicalDeviceSurfaceFormatsKHR, PFN_vkGetPhysicalDeviceSurfaceFormatsKHR => gfxGetPhysicalDeviceSurfaceFormatsKHR,
         vkGetPhysicalDeviceSurfacePresentModesKHR, PFN_vkGetPhysicalDeviceSurfacePresentModesKHR => gfxGetPhysicalDeviceSurfacePresentModesKHR,
+        vkGetPhysicalDeviceWin32PresentationSupportKHR, PFN_vkGetPhysicalDeviceWin32PresentationSupportKHR => gfxGetPhysicalDeviceWin32PresentationSupportKHR,
     }
 }

--- a/libportability/src/lib.rs
+++ b/libportability/src/lib.rs
@@ -240,6 +240,14 @@ pub extern "C" fn vkGetPhysicalDeviceSurfacePresentModesKHR(
 }
 
 #[no_mangle]
+pub extern "C" fn vkGetPhysicalDeviceWin32PresentationSupportKHR(
+    adapter: VkPhysicalDevice,
+    queueFamilyIndex: u32,
+) -> VkBool32 {
+    gfxGetPhysicalDeviceWin32PresentationSupportKHR(adapter, queueFamilyIndex)
+}
+
+#[no_mangle]
 pub extern "C" fn vkCreateSwapchainKHR(
     device: VkDevice,
     pCreateInfo: *const VkSwapchainCreateInfoKHR,


### PR DESCRIPTION
This PR adds vkGetPhysicalDeviceWin32PresentationSupportKHR, which will allow applications that query this work with gfx-portability. One such application is my Vulkan Hardware Capability Viewer.

Adding this function will also silences a Vulkan loader debug message that is shown for ICDs not implementing vkGetPhysicalDeviceWin32PresentationSupportKHR.

The implementation will always just return true.