### PR TITLE
Fix rustc warnings

### DIFF
--- a/libportability-gfx/src/handle.rs
+++ b/libportability-gfx/src/handle.rs
@@ -37,7 +37,7 @@ impl<T> HandleAllocation<T> {
         #[cfg(feature = "nightly")]
         {
             use std::intrinsics::type_name;
-            let name = unsafe { type_name::<T>() };
+            let name = type_name::<T>();
             REGISTRY.lock().unwrap().insert(ptr as _, name);
         }
         Handle(ptr)


### PR DESCRIPTION
This PR fixes warnings encountered with stable 1.40.0 rust toolchain. The most interesting issue is likely switch from `mem::zeroed()` and related functions to `MaybeUninit`.

While `mem::zeroed()` is not marked deprecated in the same way as `mem::uninitialized()` is, compiler still threw warning on it. However, in this case it may have been causing undefined behavior, as `EntryPoint` contains references which may not be null. Another option here would be using `Option` instead of `MaybeUninit`, which would be completely safe with some extra checks. Since original code didn't, and because valid Vulkan use requires exactly one vertex shader, I chose to use `MaybeUninit` instead.