### PR TITLE
Fix vulkan validation errors

### DIFF
--- a/libportability-gfx/src/impls.rs
+++ b/libportability-gfx/src/impls.rs
@@ -2656,8 +2656,8 @@ pub extern "C" fn gfxCreatePipelineLayout(
 
     let ranges = push_constants.iter().map(|constant| {
         let stages = conv::map_stage_flags(constant.stageFlags);
-        let start = constant.offset / 4;
-        let size = constant.size / 4;
+        let start = constant.offset;
+        let size = constant.size;
 
         (stages, start..start + size)
     });

--- a/libportability-gfx/src/impls.rs
+++ b/libportability-gfx/src/impls.rs
@@ -4294,11 +4294,13 @@ pub extern "C" fn gfxCmdExecuteCommands(
 
 #[inline]
 pub extern "C" fn gfxDestroySurfaceKHR(
-    _instance: VkInstance,
+    instance: VkInstance,
     surface: VkSurfaceKHR,
     _: *const VkAllocationCallbacks,
 ) {
-    let _ = surface.unbox(); //TODO
+    if let Some(be_surface) = surface.unbox() {
+        unsafe { instance.backend.destroy_surface(be_surface) };
+    }
 }
 
 #[inline]
@@ -4505,14 +4507,21 @@ pub extern "C" fn gfxCreateSwapchainKHR(
 }
 #[inline]
 pub extern "C" fn gfxDestroySwapchainKHR(
-    _gpu: VkDevice,
+    gpu: VkDevice,
     mut swapchain: VkSwapchainKHR,
     _pAllocator: *const VkAllocationCallbacks,
 ) {
     for image in &mut swapchain.images {
         let _ = image.unbox();
     }
-    let _ = swapchain.unbox();
+
+    if let Some(Swapchain {
+        raw: Some(be_swapchain),
+        ..
+    }) = swapchain.unbox()
+    {
+        unsafe { gpu.device.destroy_swapchain(be_swapchain) };
+    }
 }
 #[inline]
 pub extern "C" fn gfxGetSwapchainImagesKHR(


### PR DESCRIPTION
This PR fixes some validation errors when running Sascha Willems samples using portability on top of Vulkan. For now, only some of the basic samples are fixed and only when fix doesn't require changes in gfx-hal.